### PR TITLE
Improve portability to older perl versions.

### DIFF
--- a/Makefile.pm
+++ b/Makefile.pm
@@ -35,7 +35,7 @@ sub makefile {
 
    $config->{tag}        = "$config->{orgname}/$config->{tag}";
 
-   my @targets = keys $config->{targets};
+   my @targets = keys %{ $config->{targets} };
    print "Building for [@targets]\n";
 
    for my $target (@targets) {
@@ -54,7 +54,7 @@ sub makefile {
       my $vars = $config->{targets}{$target};
       for my $srcfile (<src/*.in>) {
          my $lines = slurp $srcfile;
-         for my $var (keys $vars) {
+         for my $var (keys %$vars) {
             $lines =~ s/\@$var\@/$vars->{$var}/g;
          }
          if (my @unresolved = $lines =~ /\@(\w+)\@/g) {


### PR DESCRIPTION
`keys` on hash references is experimental in 5.20.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/5)
<!-- Reviewable:end -->
