### PR TITLE
Patch nettle configure script to look for a different symbol.

### DIFF
--- a/ghc-android/src/user-scripts/build-nettle.sh
+++ b/ghc-android/src/user-scripts/build-nettle.sh
@@ -7,6 +7,7 @@ cd $NDK_ADDON_SRC
 apt-get source nettle
 
 pushd nettle*
+sed -i -e 's/__gmpz_mpz_powm/__gmpz_powm/' configure.ac
 autoreconf -fi
 ./configure --prefix="$NDK_ADDON_PREFIX" --host=$NDK_TARGET --build=$BUILD_ARCH --with-build-cc=$BUILD_GCC --enable-static --disable-shared
 make $MAKEFLAGS


### PR DESCRIPTION
Apparently the symbol it's looking for isn't in gmp 6.1.1, making it
think that the version is older than 5.0. Wonderful!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/7)
<!-- Reviewable:end -->
