### PR TITLE
Correctly compute the path of set-env.sh in set-env-android.sh.

### DIFF
--- a/ghc-android/src/user-scripts/set-env-android.sh
+++ b/ghc-android/src/user-scripts/set-env-android.sh
@@ -6,7 +6,7 @@
 # GHC build dependencies for the Android cross compiler.
 #
 
-. set-env.sh
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/set-env.sh"
 
 # Basic parameters
 NDK_RELEASE=${NDK_RELEASE:-r12b}


### PR DESCRIPTION
This way, we can import set-env-android.sh from user scripts running
outside of the ghc-build directory (e.g. the work directory).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/28)
<!-- Reviewable:end -->
