### PR TITLE
Remove dependencies from buildfarm/Makefile.

### DIFF
--- a/buildfarm/Makefile
+++ b/buildfarm/Makefile
@@ -3,13 +3,13 @@ build: build-builder build-buildfarm-base build-buildfarm-server build-buildfarm
 build-builder:
 	docker build builder -t toxchat/builder:1.0.0
 
-build-buildfarm-base: build-builder
+build-buildfarm-base:
 	docker build base -t toxchat/buildfarm-base:1.0.0
 
-build-buildfarm-server: build-buildfarm-base
+build-buildfarm-server:
 	docker build server -t toxchat/buildfarm-server:1.0.0
 
-build-buildfarm-worker: build-buildfarm-base
+build-buildfarm-worker:
 	docker build worker -t toxchat/buildfarm-worker:1.0.0
 
 


### PR DESCRIPTION
Having them is nice, but it causes Circle CI to rebuild buildfarm-base
when building -worker and -server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/31)
<!-- Reviewable:end -->
