### PR TITLE
Use docker layer caching to speed up builds.

### DIFF
--- a/.circleci/build-image
+++ b/.circleci/build-image
@@ -1,7 +1,15 @@
 #!/bin/sh
 
+# Run this before set -eux so we don't print credentials to the CI logs.
+echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
+
+set -eux
+
+BUILD="$1"
+IMAGE="$2"
+
 apk add make perl docker-cli
 make
-echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
-make -C $1 build-$2
-make -C $1 push-$2
+docker pull "$IMAGE" || true
+docker build --cache-from "$IMAGE" --tag "$IMAGE" "$BUILD"
+docker push "$IMAGE"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,15 @@ workflows:
           requires: [buildfarm-base]
       - buildfarm-worker:
           requires: [builder, buildfarm-base]
-# Disabled GHC for now, because we're not actively developing it and it takes
-# hours to build these.
-#     - ghc-base
-#     - ghc-android-aarch64:
-#         requires: [ghc-base]
-#     - ghc-android-arm:
-#         requires: [ghc-base]
-#     - ghc-android-i686:
-#         requires: [ghc-base]
-#     - ghc-android-x86_64:
-#         requires: [ghc-base]
+      - ghc-base
+      - ghc-android-aarch64:
+          requires: [ghc-base]
+      - ghc-android-arm:
+          requires: [ghc-base]
+      - ghc-android-i686:
+          requires: [ghc-base]
+      - ghc-android-x86_64:
+          requires: [ghc-base]
 
 jobs:
   ##################################################
@@ -36,7 +34,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm builder
+      - run: .circleci/build-image buildfarm/builder toxchat/builder:1.0.0
 
   buildfarm-base:
     docker: [{image: alpine:3.11.5}]
@@ -44,7 +42,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm buildfarm-base
+      - run: .circleci/build-image buildfarm/base toxchat/buildfarm-base:1.0.0
 
   buildfarm-server:
     docker: [{image: alpine:3.11.5}]
@@ -52,7 +50,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm buildfarm-server
+      - run: .circleci/build-image buildfarm/server toxchat/buildfarm-server:1.0.0
 
   buildfarm-worker:
     docker: [{image: alpine:3.11.5}]
@@ -60,7 +58,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm buildfarm-worker
+      - run: .circleci/build-image buildfarm/worker toxchat/buildfarm-worker:1.0.0
 
   ##################################################
   #
@@ -74,7 +72,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image ghc base
+      - run: .circleci/build-image ghc/base toktoknet/ghc:8.6.5
 
   ghc-android-aarch64:
     docker: [{image: alpine:3.11.5}]
@@ -82,7 +80,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image ghc-android aarch64
+      - run: .circleci/build-image ghc-android/aarch64 toktoknet/ghc-android:8.6.5.aarch64
 
   ghc-android-arm:
     docker: [{image: alpine:3.11.5}]
@@ -90,7 +88,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image ghc-android arm
+      - run: .circleci/build-image ghc-android/arm toktoknet/ghc-android:8.6.5.arm
 
   ghc-android-i686:
     docker: [{image: alpine:3.11.5}]
@@ -98,7 +96,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image ghc-android i686
+      - run: .circleci/build-image ghc-android/i686 toktoknet/ghc-android:8.6.5.i686
 
   ghc-android-x86_64:
     docker: [{image: alpine:3.11.5}]
@@ -106,4 +104,4 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image ghc-android x86_64
+      - run: .circleci/build-image ghc-android/x86_64 toktoknet/ghc-android:8.6.5.x86_64


### PR DESCRIPTION
This should speed up GHC image builds so much that it's essentially free
to run them on every push, so this PR re-enables those builds.

See https://semaphoreci.com/docs/docker/docker-layer-caching.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/32)
<!-- Reviewable:end -->
