### PR TITLE
Install docker before trying to give it credentials.

### DIFF
--- a/.circleci/build-image
+++ b/.circleci/build-image
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Install docker.
+apk add make perl docker-cli
+
 # Run this before set -eux so we don't print credentials to the CI logs.
 echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
 
@@ -8,7 +11,6 @@ set -eux
 BUILD="$1"
 IMAGE="$2"
 
-apk add make perl docker-cli
 make
 docker pull "$IMAGE" || true
 docker build --cache-from "$IMAGE" --tag "$IMAGE" "$BUILD"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm/builder toxchat/builder:1.0.0
+      - run: .circleci/build-image buildfarm/builder toxchat/builder:latest
 
   buildfarm-base:
     docker: [{image: alpine:3.11.5}]
@@ -42,7 +42,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm/base toxchat/buildfarm-base:1.0.0
+      - run: .circleci/build-image buildfarm/base toxchat/buildfarm-base:latest
 
   buildfarm-server:
     docker: [{image: alpine:3.11.5}]
@@ -50,7 +50,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm/server toxchat/buildfarm-server:1.0.0
+      - run: .circleci/build-image buildfarm/server toxchat/buildfarm-server:latest
 
   buildfarm-worker:
     docker: [{image: alpine:3.11.5}]
@@ -58,7 +58,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: .circleci/build-image buildfarm/worker toxchat/buildfarm-worker:1.0.0
+      - run: .circleci/build-image buildfarm/worker toxchat/buildfarm-worker:latest
 
   ##################################################
   #

--- a/buildfarm/base/Dockerfile
+++ b/buildfarm/base/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:16.04 AS build
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
- ca-certificates=20170717~16.04.2 \
- g++=4:5.3.1-1ubuntu1 \
- git=1:2.7.4-0ubuntu1.9 \
- openjdk-8-jdk-headless=8u242-b08-0ubuntu3~16.04 \
- unzip=6.0-20ubuntu1 \
- wget=1.17.1-1ubuntu1.5 \
- zlib1g-dev=1:1.2.8.dfsg-2ubuntu4.3 \
+ ca-certificates \
+ g++ \
+ git \
+ openjdk-8-jdk-headless \
+ unzip \
+ wget \
+ zlib1g-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/buildfarm/builder/Dockerfile
+++ b/buildfarm/builder/Dockerfile
@@ -2,13 +2,13 @@ FROM ubuntu:16.04
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
- binutils=2.26.1-1ubuntu1~16.04.8 \
- curl=7.47.0-1ubuntu2.14 \
- libstdc++-5-dev=5.4.0-6ubuntu1~16.04.12 \
- openjdk-8-jdk-headless=8u242-b08-0ubuntu3~16.04 \
- libc6-dev=2.23-0ubuntu11 \
- python3=3.5.1-3 \
- python3.5-dev=3.5.2-2ubuntu0~16.04.10 \
+ binutils \
+ curl \
+ libstdc++-5-dev \
+ openjdk-8-jdk-headless \
+ libc6-dev \
+ python3 \
+ python3.5-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/buildfarm/server/Dockerfile
+++ b/buildfarm/server/Dockerfile
@@ -1,4 +1,5 @@
-FROM toxchat/buildfarm-base:1.0.0 as base
+# hadolint ignore=DL3007
+FROM toxchat/buildfarm-base:latest as base
 FROM alpine:3.11.5
 RUN apk --no-cache add openjdk8
 

--- a/buildfarm/worker/Dockerfile
+++ b/buildfarm/worker/Dockerfile
@@ -1,5 +1,7 @@
-FROM toxchat/buildfarm-base:1.0.0 as base
-FROM toxchat/builder:1.0.0
+# hadolint ignore=DL3007
+FROM toxchat/buildfarm-base:latest as base
+# hadolint ignore=DL3007
+FROM toxchat/builder:latest
 
 COPY --from=base /buildfarm-operationqueue-worker_deploy.jar /
 COPY logging.properties worker.config /config/


### PR DESCRIPTION
Also, remove the explicit versions for installing apt-get packages. Also,
removed explicit versions for buildfarm images. Versioning these is not
useful, I just did that because of a linter, and while the linter is
right in most cases, these are images we build ourselves, and "latest" is
the only thing we care about here. The images should really not change
much over time anyway, so they shouldn't become incompatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/33)
<!-- Reviewable:end -->
