### PR TITLE
fix: Disable haskell builds in kythe indexing.

### DIFF
--- a/kythe/buildenv/build_index.sh
+++ b/kythe/buildenv/build_index.sh
@@ -7,6 +7,8 @@ set -eux
 # from different repositories. E.g. both dockerfiles and toktok-stack want to
 # push this image.
 bazel --bazelrc=/opt/kythe/extractors.bazelrc build \
+  --build_tag_filters=-haskell \
+  --test_tag_filters=-haskell \
   --config=clang \
   --override_repository kythe_release=/opt/kythe \
   //c-toxcore/... \


### PR DESCRIPTION
GHC needs tinfo, and the image doesn't have that yet. Also, building
haskell stuff has no use in kythe because we don't have a haskell
indexer yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/43)
<!-- Reviewable:end -->
