### PR TITLE
perf: Only push final Kythe tables to the kythe-tables image.

### DIFF
--- a/kythe/tables/Dockerfile
+++ b/kythe/tables/Dockerfile
@@ -1,5 +1,5 @@
 # Extract index.
-FROM toxchat/kythe-buildenv:latest
+FROM toxchat/kythe-buildenv:latest AS tables
 
 # From: https://kythe.io/examples/#extracting-other-bazel-based-repositories
 RUN ["git", "clone", "--depth=50", "--recursive", "-j8",\
@@ -7,3 +7,6 @@ RUN ["git", "clone", "--depth=50", "--recursive", "-j8",\
  "/src/workspace"]
 
 RUN ["/opt/build_index.sh"]
+
+FROM scratch
+COPY --from=tables /data /data


### PR DESCRIPTION
This reduces the size from 5GB to a few hundred MB, at the cost of not
having a cache, ever. That's ok though, because toktok-stack is
frequently updated, so the cache would be in the way anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/65)
<!-- Reviewable:end -->
