### PR TITLE
chore: Clean up kythe buildenv.

### DIFF
--- a/buildfarm/builder/Dockerfile
+++ b/buildfarm/builder/Dockerfile
@@ -21,4 +21,5 @@ RUN BASE_URL=https://storage.googleapis.com/clang-builds-stable/clang-ubuntu18_0
  && curl "$BASE_URL/libcxx-msan_r$VERSION.tar.gz" | tar zxv -C /usr/local/ \
  && curl "$BASE_URL/lld_r$VERSION.tar.gz" | tar zxv -C /usr/local/
 
+ENV CC=/usr/local/bin/clang CXX=/usr/local/bin/clang++
 ENV JAVA_HOME=/usr/lib/jvm/default-java

--- a/kythe/buildenv/Dockerfile
+++ b/kythe/buildenv/Dockerfile
@@ -4,22 +4,12 @@ FROM toxchat/kythe-release:latest AS release
 FROM toxchat/bazel:latest
 
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
- libasound-dev \
- libncurses5-dev \
- libncursesw5-dev \
- libssl-dev \
- libx11-dev \
- parallel \
- unzip \
- zlib1g-dev \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends parallel \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=SC3001
 RUN bash <(curl https://raw.githubusercontent.com/TokTok/toktok-stack/master/tools/prepare_android_sdk.sh)
-
-ENV CC=clang CXX=clang++
 
 COPY --from=release /opt/kythe /opt/kythe
 COPY build_index.sh /opt/


### PR DESCRIPTION
It no longer needs to install extra dependencies. The bazel image already
does this now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/70)
<!-- Reviewable:end -->
