### PR TITLE
feat: Make valgrind available in the bazel base image.

### DIFF
--- a/buildfarm/bazel/Dockerfile
+++ b/buildfarm/bazel/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
  qttools5-dev \
  qttools5-dev-tools \
  unzip \
+ valgrind \
  wget \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This allows us to run tests under valgrind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/72)
<!-- Reviewable:end -->
