### PR TITLE
chore: Add sudo, gdb, ssh, and strace to the bazel image.

### DIFF
--- a/buildfarm/bazel/Dockerfile
+++ b/buildfarm/bazel/Dockerfile
@@ -1,8 +1,9 @@
 FROM toxchat/builder:latest
 
-# Install Bazel and toktok-stack dependencies.
+# Install Bazelisk, some debugging tools, and all toktok-stack system dependencies.
 RUN apt-get update \
  && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+ gdb \
  git \
  libasound2-dev \
  libgmp-dev \
@@ -18,9 +19,12 @@ RUN apt-get update \
  libxxf86vm-dev \
  make \
  maven \
+ openssh-client \
  qtmultimedia5-dev \
  qttools5-dev \
  qttools5-dev-tools \
+ strace \
+ sudo \
  unzip \
  valgrind \
  wget \


### PR DESCRIPTION
sudo will be used to allow the builder user to run root commands when
needed. gdb and strace can be used to debug binaries directly in the
container. ssh is needed for git to clone repos via ssh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/76)
<!-- Reviewable:end -->
