### PR TITLE
chore: Remove android stuff from kythe buildenv.

### DIFF
--- a/kythe/buildenv/Dockerfile
+++ b/kythe/buildenv/Dockerfile
@@ -8,9 +8,6 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# hadolint ignore=SC3001
-RUN bash <(curl https://raw.githubusercontent.com/TokTok/toktok-stack/master/tools/prepare_android_sdk.sh)
-
 COPY --from=release /opt/kythe /opt/kythe
 COPY build_index.sh /opt/
 

--- a/kythe/buildenv/build_index.sh
+++ b/kythe/buildenv/build_index.sh
@@ -2,10 +2,6 @@
 
 set -eux
 
-# Android SDK is needed even when we don't build Android stuff because WORKSPACE
-# configuration fails otherwise.
-ln -s /third_party/android/sdk third_party/android/sdk
-
 # We list the packages to build here instead of in the "tables" image, because
 # we should never build a different set of paths in that image when building
 # from different repositories. E.g. both dockerfiles and toktok-stack want to


### PR DESCRIPTION
It's no longer needed as of
https://github.com/TokTok/toktok-stack/pull/337.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/79)
<!-- Reviewable:end -->
