### PR TITLE
fix: Fix Flutter SDK version being assumed to be 0.0.0-unknown

### DIFF
--- a/flutter/web/Dockerfile
+++ b/flutter/web/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Clone the flutter repo
-RUN git clone --depth=1 https://github.com/flutter/flutter.git /usr/local/flutter
+RUN git clone https://github.com/flutter/flutter.git /usr/local/flutter
 
 # Set flutter path
 # RUN /usr/local/flutter/bin/flutter doctor -v


### PR DESCRIPTION
This happens because the version is worked out from the git tags in the
cloned repo.

This causes issues in e.g. dependency resolution as some libraries specify supported Flutter SDK versions.
```
#30 12.27 Running "flutter pub get" in app...
#30 14.53 The current Flutter SDK version is 0.0.0-unknown.
#30 14.53
#30 14.53 Because btox depends on sqlite3_flutter_libs >=0.1.0 which requires Flutter SDK version >=1.10.1, version solving failed.
#30 14.58 pub get failed (1; Because btox depends on sqlite3_flutter_libs >=0.1.0 which requires Flutter SDK version >=1.10.1, version solving failed.)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/88)
<!-- Reviewable:end -->
