### PR TITLE
chore: Install libtinfo-dev in haskell image.

### DIFF
--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
  ca-certificates \
  curl \
  git \
+ libtinfo-dev \
  && curl -sSL https://get.haskellstack.org/ | sh \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
stack build fails without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/dockerfiles/90)
<!-- Reviewable:end -->
