### PR TITLE
chore: Update to required bazel versions for buildfarm and kythe.

### DIFF
--- a/buildfarm/base/Dockerfile
+++ b/buildfarm/base/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Install bazel.
-RUN wget -q https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel_4.0.0-linux-x86_64.deb \
- && dpkg -i bazel_4.0.0-linux-x86_64.deb \
- && rm bazel_4.0.0-linux-x86_64.deb
+RUN wget -q https://github.com/bazelbuild/bazel/releases/download/6.1.2/bazel_6.1.2-linux-x86_64.deb \
+ && dpkg -i bazel_6.1.2-linux-x86_64.deb \
+ && rm bazel_6.1.2-linux-x86_64.deb
 
 # Download and build buildfarm.
 RUN ["git", "clone", "--depth=1",\

--- a/kythe/webui/Dockerfile
+++ b/kythe/webui/Dockerfile
@@ -1,5 +1,5 @@
 # Build webui.
-FROM debian:stretch
+FROM debian:bookworm
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -20,9 +20,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q https://github.com/bazelbuild/bazel/releases/download/4.2.0/bazel_4.2.0-linux-x86_64.deb \
- && dpkg -i bazel_4.2.0-linux-x86_64.deb \
- && rm bazel_4.2.0-linux-x86_64.deb
+RUN wget -q https://github.com/bazelbuild/bazel/releases/download/6.3.0/bazel_6.3.0-linux-x86_64.deb \
+ && dpkg -i bazel_6.3.0-linux-x86_64.deb \
+ && rm bazel_6.3.0-linux-x86_64.deb
 
 WORKDIR /src/kythe
 RUN git clone --depth=1 https://github.com/kythe/kythe /src/kythe


### PR DESCRIPTION
Also update debian to latest stable. `stretch` is actually gone now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/103)
<!-- Reviewable:end -->
