### PR TITLE
chore: Disable rust and typescript kythe extractors.

### DIFF
--- a/kythe/release/Dockerfile
+++ b/kythe/release/Dockerfile
@@ -11,5 +11,5 @@ RUN apt-get update \
 RUN wget -q -O /tmp/kythe.tar.gz https://github.com/kythe/kythe/releases/download/v0.0.63/kythe-v0.0.63.tar.gz
 RUN tar --no-same-owner -xvzf /tmp/kythe.tar.gz --directory /opt
 RUN mv /opt/kythe-v0.0.63 /opt/kythe
-# Fix rust toolchain path.
-RUN sed -i -e 's/rust_linux_x86_64__x86_64-unknown-linux-gnu_tools/rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/' /opt/kythe/BUILD
+# Disable rust and typescript extractors (we don't use these languages).
+RUN sed -E -i -e '/:extract_kzip_(rust|typescript)/ s/^/#/' /opt/kythe/extractors.bazelrc


### PR DESCRIPTION
Rust requires 800MB of rust toolchain, which exceeds the github actions disk space.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/110)
<!-- Reviewable:end -->
