### PR TITLE
fix: chown flutter sdk to root:root.

### DIFF
--- a/flutter/web/Dockerfile
+++ b/flutter/web/Dockerfile
@@ -21,15 +21,17 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Clone the flutter repo
-RUN git clone https://github.com/flutter/flutter.git /usr/local/flutter
+RUN ["git", "clone", "--depth=1", "https://github.com/flutter/flutter.git", "/usr/local/flutter"]
 
 # Set flutter path
 # RUN /usr/local/flutter/bin/flutter doctor -v
 ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PATH}"
 
 # Run flutter doctor
-RUN flutter doctor -v
+RUN ["flutter", "doctor", "-v"]
 # Enable flutter web
-RUN flutter channel master
-RUN flutter upgrade
-RUN flutter config --enable-web
+RUN ["flutter", "channel", "master"]
+RUN ["flutter", "upgrade"]
+RUN ["flutter", "config", "--enable-web"]
+# Fix ownership: flutter extracts a tarball with some arbitrary UID/GID.
+RUN find /usr/local -not -uid 0 -or -not -gid 0 -print0 | xargs -0 chown root:root


### PR DESCRIPTION
Without this, there are random UID/GIDs without assigned user/group, which confuses non-root docker daemons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/111)
<!-- Reviewable:end -->
