### PR TITLE
cleanup: Remove useless flutter upgrade command

### DIFF
--- a/flutter/web/Dockerfile
+++ b/flutter/web/Dockerfile
@@ -31,7 +31,6 @@ ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PAT
 RUN ["flutter", "doctor", "-v"]
 # Enable flutter web
 RUN ["flutter", "channel", "master"]
-RUN ["flutter", "upgrade"]
 RUN ["flutter", "config", "--enable-web"]
 # Fix ownership: flutter extracts a tarball with some arbitrary UID/GID.
 RUN find /usr/local -not -uid 0 -or -not -gid 0 -print0 | xargs -0 chown root:root


### PR DESCRIPTION
Not needed, as channel change already does it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/112)
<!-- Reviewable:end -->
