### PR TITLE
cleanup: Use the master id_rsa.pub.

### DIFF
--- a/alpine-s390x/src/setup-vm.expect
+++ b/alpine-s390x/src/setup-vm.expect
@@ -4,8 +4,7 @@ set timeout -1
 
 set alpine_repo "https://dl-cdn.alpinelinux.org/alpine/v3.19/main"
 set modloop "https://dl-cdn.alpinelinux.org/alpine/v3.19/releases/s390x/netboot/modloop-lts"
-# TODO(iphydf): Once merged, change this to point at TokTok master.
-set ssh_key "https://raw.githubusercontent.com/iphydf/dockerfiles/s390x/alpine-s390x/src/id_rsa.pub"
+set ssh_key "https://raw.githubusercontent.com/TokTok/dockerfiles/master/alpine-s390x/src/id_rsa.pub"
 
 # We disable Kernel-ASLR because there's no hardware RNG.
 spawn qemu-system-s390x \

--- a/freebsd/src/setup-vm
+++ b/freebsd/src/setup-vm
@@ -11,7 +11,6 @@ gunzip "$IMAGE_NAME.gz"
 
 NPROC="$NPROC" SSH_PORT="$SSH_PORT" IMAGE_NAME="$IMAGE_NAME" script -c "TERM=screen screen /work/setup-vm.expect"
 
-reset || true
 start_vm
 
 # Update system


### PR DESCRIPTION
We needed it from iphydf for bootstrapping (CI). Now we can use it from master, because it's available now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/132)
<!-- Reviewable:end -->
