### PR TITLE
chore(deps): Preinstall more toxcore dependencies in the s390x image.

### DIFF
--- a/alpine-s390x/src/setup-vm.expect
+++ b/alpine-s390x/src/setup-vm.expect
@@ -20,8 +20,9 @@ spawn qemu-system-s390x \
 expect "localhost login:"
 send -- "root\r"
 
+# Install compiler and other dependencies to build toxcore.
 expect "localhost:~#"
-send -- "apk add gcc libsodium-dev linux-headers musl-dev perl\r"
+send -- "apk add cmake gcc g++ libsodium-dev linux-headers musl-dev ninja perl\r"
 
 expect "localhost:~#"
 # ctrl-a c (switch to qemu monitor console)


### PR DESCRIPTION
Avoids having to do this in the toxcore CI build. Saves about half a minute in the s390x build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/133)
<!-- Reviewable:end -->
