### PR TITLE
chore: Upgrade nixos to 23.11.

### DIFF
--- a/buildfarm/bazel/Dockerfile
+++ b/buildfarm/bazel/Dockerfile
@@ -4,21 +4,21 @@ ADD squashed.tar /
 # Reinstate the CMD directive from the squashed image.
 CMD ["/usr/sbin/init"]
 
-# Using WORKDIR as a built-in "mkdir", because the symlinks to mkdir aren't
-# set up yet.
+# We need to know where our bash is, because we haven't set up /bin/sh yet.
+SHELL ["/nix/store/x88ivkf7rmrhd5x3cvyv5vh3zqqdnhsk-bash-interactive-5.2-p15/bin/bash", "-o", "pipefail", "-c"]
+
+# Run activation script (init knows where it is).
+RUN /usr/sbin/init || true
+ENV PATH="/etc/profiles/per-user/builder/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
+
+# Create suid/sgid wrappers so sudo works in the rest of the docker build.
 WORKDIR /run/wrappers
+RUN "$(grep -o '/nix/store/.*/suid-sgid-wrappers-start' /etc/systemd/system/suid-sgid-wrappers.service)"
 
-ENV PATH="/nix/store/ahkfdxq8mcpsb5kvdvgqr1wv8zjngbh4-coreutils-9.1/bin"
-
-# Required by the activation script
-RUN ["install", "-m", "0755", "-d", "/etc", "/etc/nixos"]
-RUN ["install", "-m", "01777", "-d", "/tmp"]
-
-# Run the script that performs all configuration activation that does
-# not have to be done at boot time.
-RUN ["cut", "-d\n", "-f3", "/usr/sbin/init"]
-RUN ["/nix/store/y3xwfp77dy7g0lm33dahfbnggvnwbj1p-nixos-system-unnamed-23.05pre-git/activate"]
-
+WORKDIR /home/builder
 USER builder
-ENV USER="builder" \
-    PATH="/run/wrappers/bin:/etc/profiles/per-user/builder/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
+ENV USER="builder" PATH="/run/wrappers/bin:$PATH"
+
+# Test whether the suid/sgid wrapper script worked.
+RUN sudo true
+RUN bazel --version

--- a/buildfarm/bazel/arion-compose.nix
+++ b/buildfarm/bazel/arion-compose.nix
@@ -15,7 +15,7 @@ in {
         services.openssh.enable = true;
         services.nscd.enable = false;
 
-        system.stateVersion = "23.05";
+        system.stateVersion = "23.11";
         system.nssModules = lib.mkForce [];
 
         systemd.sockets.nix-daemon.enable = true;

--- a/buildfarm/bazel/arion-pkgs.nix
+++ b/buildfarm/bazel/arion-pkgs.nix
@@ -1,7 +1,7 @@
 let
   nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.05.tar.gz";
-    sha256 = "sha256:10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.11.tar.gz";
+    sha256 = "sha256:1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
   };
 in
   (import nixpkgs { system = "x86_64-linux"; }).pkgs


### PR DESCRIPTION
Primary change is that now the activation script no longer sets up suid/sgid wrappers, and that functionality now moved to a systemd service, which we need to run manually in the docker build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/141)
<!-- Reviewable:end -->
