### PR TITLE
chore: Rename qtox images to all be in the same dockerhub repo.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,6 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - alpine
           - android-builder
           - debian
           - fedora
@@ -135,7 +136,7 @@ jobs:
           build-args: |
             ARCH=${{ matrix.arch }}
             WINEARCH=${{ matrix.winearch }}
-          tags: toxchat/qtox-${{ matrix.image }}:latest
+          tags: toxchat/qtox:${{ matrix.image }}
           cache-from: type=registry,ref=toxchat/qtox-${{ matrix.image }}:latest
           cache-to: type=inline
           push: ${{ github.event_name == 'push' }}

--- a/qtox/docker/Dockerfile.alpine
+++ b/qtox/docker/Dockerfile.alpine
@@ -23,24 +23,24 @@ RUN ["apk", "add", \
 
 ENV CC=clang CXX=clang++
 
-RUN git clone --recurse-submodules --depth=1 https://github.com/TokTok/c-toxcore /work/c-toxcore
 WORKDIR /work/c-toxcore
-RUN cmake -B_build -H. -GNinja
-RUN cmake --build _build --target install
+RUN git clone --recurse-submodules --depth=1 https://github.com/TokTok/c-toxcore /work/c-toxcore \
+ && cmake -B_build -H. -GNinja \
+ && cmake --build _build --target install \
+ && rm -rf /work/c-toxcore
 
-RUN git clone --recurse-submodules --depth=1 https://github.com/toxext/toxext /work/toxext
 WORKDIR /work/toxext
 # Tests enable asan unconditionally, which doesn't work on Alpine.
-RUN sed -i -e 's/add_subdirectory(test)/#\1/' CMakeLists.txt
-RUN cmake -B_build -H. -GNinja
-RUN cmake --build _build --target install
+RUN git clone --recurse-submodules --depth=1 https://github.com/toxext/toxext /work/toxext \
+ && sed -i -e 's/add_subdirectory(test)/#\1/' CMakeLists.txt \
+ && cmake -B_build -H. -GNinja \
+ && cmake --build _build --target install \
+ && rm -rf /work/toxext
 
-RUN git clone --recurse-submodules --depth=1 https://github.com/toxext/tox_extension_messages /work/tox_extension_messages
 WORKDIR /work/tox_extension_messages
-RUN cmake -B_build -H. -GNinja
-RUN cmake --build _build --target install
+RUN git clone --recurse-submodules --depth=1 https://github.com/toxext/tox_extension_messages /work/tox_extension_messages \
+ && cmake -B_build -H. -GNinja \
+ && cmake --build _build --target install \
+ && rm -rf /work/tox_extension_messages
 
-COPY . /work/qtox
-WORKDIR /work/qtox
-RUN cmake -B_build -H. -GNinja
-RUN cmake --build _build --target install
+WORKDIR /qtox


### PR DESCRIPTION
We don't need multiple tags per image, so we just use tags to differentiate them, like we do in toktok-stack.

Also added an alpine image build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/162)
<!-- Reviewable:end -->
