### PR TITLE
chore: Add ccache to qtox builder images.

### DIFF
--- a/qtox/docker/Dockerfile.alpine
+++ b/qtox/docker/Dockerfile.alpine
@@ -1,7 +1,11 @@
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2024 The TokTok team
+
 FROM alpine:3.20
 
 RUN ["apk", "add", \
  "bash", \
+ "ccache", \
  "clang", \
  "cmake", \
  "compiler-rt", \
@@ -33,3 +37,4 @@ RUN git clone --recurse-submodules --depth=1 https://github.com/TokTok/c-toxcore
  && rm -rf /work/c-toxcore
 
 WORKDIR /qtox
+ENV HOME=/qtox

--- a/qtox/docker/Dockerfile.android-builder
+++ b/qtox/docker/Dockerfile.android-builder
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2024 The TokTok team
+
 ARG QT_VERSION=6.2.4
 #ARG QT_VERSION=6.8.1
 
@@ -14,6 +17,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
  "build-essential" \
  "bzip2" \
  "ca-certificates" \
+ "ccache" \
  "clang" \
  "cmake" \
  "g++" \
@@ -348,4 +352,6 @@ RUN tar zxf <(wget -O- https://github.com/TokTok/c-toxcore/releases/download/v0.
 
 # Make .android world-writable (like /tmp) so debug signing works.
 RUN ["chmod", "1777", "/work/android/sdk/.android"]
+
 WORKDIR /qtox
+ENV HOME=/qtox

--- a/qtox/docker/Dockerfile.archlinux
+++ b/qtox/docker/Dockerfile.archlinux
@@ -1,17 +1,6 @@
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 FROM archlinux:latest
 
@@ -46,3 +35,4 @@ RUN mkdir -p /src/tox && \
     rm -fr /src/tox
 
 WORKDIR /qtox
+ENV HOME=/qtox

--- a/qtox/docker/Dockerfile.debian
+++ b/qtox/docker/Dockerfile.debian
@@ -1,17 +1,6 @@
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 FROM debian:stable
 
@@ -21,6 +10,7 @@ RUN apt-get update \
  && apt-get -y --force-yes --no-install-recommends install \
  build-essential \
  ca-certificates \
+ ccache \
  cmake \
  curl \
  extra-cmake-modules \
@@ -55,3 +45,4 @@ RUN mkdir -p /src/tox && \
     rm -fr /src/tox
 
 WORKDIR /qtox
+ENV HOME=/qtox

--- a/qtox/docker/Dockerfile.fedora
+++ b/qtox/docker/Dockerfile.fedora
@@ -1,23 +1,13 @@
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 FROM fedora:latest
 
 RUN dnf --nodocs -y install dnf-plugins-core && \
     dnf --nodocs -y install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm && \
     dnf --nodocs -y install \
+        ccache \
         clang \
         clang-tools-extra \
         cmake \
@@ -63,3 +53,4 @@ RUN echo '/usr/local/lib64/' >> /etc/ld.so.conf.d/locallib.conf && \
     ldconfig
 
 WORKDIR /qtox
+ENV HOME=/qtox

--- a/qtox/docker/Dockerfile.flatpak-builder
+++ b/qtox/docker/Dockerfile.flatpak-builder
@@ -1,17 +1,6 @@
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 FROM debian:bookworm
 

--- a/qtox/docker/Dockerfile.host-qt
+++ b/qtox/docker/Dockerfile.host-qt
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2024 The TokTok team
+
 # Build Qt for the host system.
 FROM ubuntu:22.04
 

--- a/qtox/docker/Dockerfile.ubuntu-lts
+++ b/qtox/docker/Dockerfile.ubuntu-lts
@@ -1,18 +1,6 @@
-#   Copyright © 2019-2021 by The qTox Project Contributors
-#
-#   This file is part of qTox, a Qt-based graphical interface for Tox.
-#   qTox is libre software: you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation, either version 3 of the License, or
-#   (at your option) any later version.
-#
-#   qTox is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License
-#   along with qTox.  If not, see <http://www.gnu.org/licenses/>
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2019-2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 FROM ubuntu:22.04
 
@@ -24,6 +12,7 @@ RUN apt-get update \
  automake \
  build-essential \
  ca-certificates \
+ ccache \
  cmake \
  curl \
  desktop-file-utils \
@@ -91,3 +80,4 @@ RUN echo '/usr/local/lib/' >> /etc/ld.so.conf.d/locallib.conf && \
     ldconfig
 
 WORKDIR /qtox
+ENV HOME=/qtox

--- a/qtox/docker/Dockerfile.windows-builder
+++ b/qtox/docker/Dockerfile.windows-builder
@@ -1,17 +1,6 @@
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later.
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 FROM ubuntu:24.10
 
@@ -31,6 +20,7 @@ RUN dpkg --add-architecture i386 \
  automake \
  build-essential \
  ca-certificates \
+ ccache \
  cmake \
  curl \
  extra-cmake-modules \
@@ -243,7 +233,7 @@ RUN mkdir -p /src/gdb && \
   rm -fr /src/gdb && \
   cp /windows/bin/gdb.exe /debug_export/gdb.exe
 
-RUN mkdir -p /qtox
-WORKDIR /qtox
-
 RUN chmod 0644 /build/windows-toolchain.cmake
+
+WORKDIR /qtox
+ENV HOME=/qtox


### PR DESCRIPTION
This won't do anything useful until we also set up ccache caching in the qtox workflows, but it's required to make that work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/179)
<!-- Reviewable:end -->
