### PR TITLE
chore: Add wine32 to windows builder image.

### DIFF
--- a/qtox/docker/Dockerfile.windows-builder
+++ b/qtox/docker/Dockerfile.windows-builder
@@ -49,6 +49,7 @@ RUN dpkg --add-architecture i386 \
  && apt-get install -y --no-install-recommends \
  winbind \
  wine-stable \
+ wine32:i386 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Apparently we need this to run tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/180)
<!-- Reviewable:end -->
