### PR TITLE
chore: Add missing tls plugins for qTox windows build.

### DIFF
--- a/qtox/docker/Dockerfile.windows-builder
+++ b/qtox/docker/Dockerfile.windows-builder
@@ -192,7 +192,8 @@ RUN mkdir /export && \
   cp /windows/lib/libvpx.a /export && \
   cp -r /windows/plugins/iconengines /export && \
   cp -r /windows/plugins/imageformats /export && \
-  cp -r /windows/plugins/platforms /export
+  cp -r /windows/plugins/platforms /export && \
+  cp -r /windows/plugins/tls /export
 
 RUN mkdir -p /debug_export
 


### PR DESCRIPTION
Bootstrap node updater was broken before this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/181)
<!-- Reviewable:end -->
