### PR TITLE
fix: Rename blake2b symbols in libsodium to avoid conflict with Qt.

### DIFF
--- a/qtox/build_sodium.sh
+++ b/qtox/build_sodium.sh
@@ -22,10 +22,15 @@ fi
 
 "$SCRIPT_DIR/download/download_sodium.sh"
 
-CFLAGS="$CROSS_CFLAG" \
+RENAME_CFLAGS=""
+for sym in blake2b blake2b_final blake2b_init blake2b_init_key blake2b_init_param blake2b_update; do
+  RENAME_CFLAGS="$RENAME_CFLAGS -D$sym=sodium_$sym"
+done
+
+CFLAGS="$CROSS_CFLAG $RENAME_CFLAGS" \
   LDFLAGS="$CROSS_LDFLAG -fstack-protector" \
   ./configure "$HOST_OPTION" \
-  "--prefix=$DEP_PREFIX" \
+  --prefix="$DEP_PREFIX" \
   "$ENABLE_STATIC" \
   "$ENABLE_SHARED"
 


### PR DESCRIPTION
Statically linked Qt contains the same symbols for its cryptographic hash implementation. They are deduped, but it's better to keep the 2 of them around for the libraries that use them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/194)
<!-- Reviewable:end -->
