### PR TITLE
chore: Use latest OpenAL on macOS.

### DIFF
--- a/qtox/build_ffmpeg.sh
+++ b/qtox/build_ffmpeg.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
-#     Copyright (c) 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
-#     Copyright (c) 2021 by The qTox Project Contributors
+# Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 set -euo pipefail
 
@@ -39,13 +40,13 @@ fi
 CFLAGS="$CROSS_CFLAG" \
   CPPFLAGS="$CROSS_CPPFLAG" \
   LDFLAGS="$CROSS_LDFLAG" \
-  ./configure "--arch=$FFMPEG_ARCH" \
+  ./configure --arch="$FFMPEG_ARCH" \
   --enable-gpl \
   "$ENABLE_STATIC" \
   "$ENABLE_SHARED" \
-  "--prefix=$DEP_PREFIX" \
-  "--target-os=$TARGET_OS" \
-  "--cross-prefix=$CROSS_PREFIX" \
+  --prefix="$DEP_PREFIX" \
+  --target-os="$TARGET_OS" \
+  --cross-prefix="$CROSS_PREFIX" \
   --pkg-config="pkg-config" \
   --extra-cflags="-O2 -g0" \
   --disable-libxcb \

--- a/qtox/download/download_openal.sh
+++ b/qtox/download/download_openal.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later AND MIT
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 set -euo pipefail
 
-OPENAL_VERSION=b80570bed017de60b67c6452264c634085c3b148
-OPENAL_HASH=e9f6d37672e085d440ef8baeebb7d62fec1d152094c162e5edb33b191462bd78
+if [ "$1" = "patched" ]; then
+  OPENAL_VERSION=b80570bed017de60b67c6452264c634085c3b148
+  OPENAL_HASH=e9f6d37672e085d440ef8baeebb7d62fec1d152094c162e5edb33b191462bd78
 
-source "$(dirname "$(realpath "$0")")/common.sh"
+  source "$(dirname "$(realpath "$0")")/common.sh"
 
-## We can stop using the fork once OpenAL-Soft gets loopback capture implemented:
-## https://github.com/kcat/openal-soft/pull/421
-download_verify_extract_tarball \
-  "https://github.com/irungentoo/openal-soft-tox/archive/$OPENAL_VERSION.tar.gz" \
-  "$OPENAL_HASH"
+  ## We can stop using the fork once OpenAL-Soft gets loopback capture implemented:
+  ## https://github.com/kcat/openal-soft/pull/421
+  download_verify_extract_tarball \
+    "https://github.com/irungentoo/openal-soft-tox/archive/$OPENAL_VERSION.tar.gz" \
+    "$OPENAL_HASH"
+else
+  OPENAL_VERSION=1.24.1
+  OPENAL_HASH=e1b6ec960e00bfed3d480330274b0f102dc10e4ae0dbb70fd9db80d6978165b1
+
+  source "$(dirname "$(realpath "$0")")/common.sh"
+
+  download_verify_extract_tarball \
+    "https://github.com/kcat/openal-soft/archive/refs/tags/$OPENAL_VERSION.tar.gz" \
+    "$OPENAL_HASH"
+fi


### PR DESCRIPTION
We only need the ancient version on Windows because of loopback. On macOS, that ancient version doesn't work anymore because it uses long gone ancient macOS APIs (Apple doesn't believe in backwards compatibility, so those APIs simply don't work anymore).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/195)
<!-- Reviewable:end -->
