### PR TITLE
cleanup: Build Qt without OpenGL support.

### DIFF
--- a/qtox/build_qt_macos.sh
+++ b/qtox/build_qt_macos.sh
@@ -13,7 +13,7 @@ parse_arch --dep "qt" --supported "macos-arm64 macos-x86_64" "$@"
 
 QT_VERSION="6.8.1"
 
-export CXXFLAGS="-DQT_MESSAGELOGCONTEXT -fsanitize=undefined,local-bounds -fsanitize-trap=all"
+export CXXFLAGS="-DQT_MESSAGELOGCONTEXT"
 export OBJCXXFLAGS="$CXXFLAGS"
 
 tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtbase-everywhere-src-$QT_VERSION.tar.xz")
@@ -21,6 +21,9 @@ cd "qtbase-everywhere-src-$QT_VERSION"
 rm -rf _build && mkdir _build && cd _build
 ../configure \
   --prefix="$DEP_PREFIX/qt" \
+  -appstore-compliant \
+  -static \
+  -release \
   -force-asserts \
   -qt-doubleconversion \
   -qt-freetype \
@@ -29,8 +32,6 @@ rm -rf _build && mkdir _build && cd _build
   -qt-libpng \
   -qt-pcre \
   -qt-zlib \
-  -appstore-compliant \
-  -static \
   -no-feature-androiddeployqt \
   -no-feature-brotli \
   -no-feature-macdeployqt \

--- a/qtox/build_qt_windows.sh
+++ b/qtox/build_qt_windows.sh
@@ -46,7 +46,7 @@ CROSS_COMPILE="$MINGW_ARCH-w64-mingw32-"
   -qt-libpng \
   -qt-zlib \
   -qt-pcre \
-  -opengl desktop \
+  -no-opengl \
   -- \
   -DCMAKE_TOOLCHAIN_FILE=/build/windows-toolchain.cmake \
   -DOPENSSL_ROOT_DIR=/windows

--- a/qtox/docker/Dockerfile.alpine-static
+++ b/qtox/docker/Dockerfile.alpine-static
@@ -449,25 +449,6 @@ FROM base AS build-qt
 
 COPY --from=build-x11 $SYSROOT/usr $SYSROOT/usr
 
-RUN tar Jxf <(curl -L https://mesa.freedesktop.org/archive/mesa-24.2.7.tar.xz) \
- && cd mesa-24.2.7 \
- && sed -i -e 's/= *shared_library(/= library(/g' $(find . -name "meson.build") \
- && LDFLAGS="-lXau -L$SYSROOT/usr/lib" meson setup _build/ \
- -Ddefault_library=static \
- -Dplatforms=x11,wayland \
- -Dgallium-vdpau=disabled \
- -Dgallium-drivers=softpipe \
- -Dvulkan-drivers= \
- -Dgles1=disabled \
- -Dgles2=disabled \
- -Dgbm=disabled \
- -Degl=disabled \
- -Dglvnd=disabled \
- -Dglx=xlib \
- --prefix="$SYSROOT/usr" || (cat _build/meson-logs/meson-log.txt && false) \
- && ninja -C _build install \
- && rm -rf /work/build
-
 RUN tar zxf <(curl https://xcb.freedesktop.org/dist/xcb-util-renderutil-0.3.10.tar.gz) \
  && cd xcb-util-renderutil-0.3.10 \
  && ./configure --prefix="$SYSROOT/usr" --disable-shared \
@@ -548,12 +529,19 @@ COPY --from=build-sqlcipher $SYSROOT/usr $SYSROOT/usr
 COPY --from=build-tslib $SYSROOT/usr $SYSROOT/usr
 COPY --from=build-zstd $SYSROOT/usr $SYSROOT/usr
 
-ARG QT_VERSION=6.8.0
+ARG QT_VERSION=6.8.1
+
+ENV CXXFLAGS="-DQT_MESSAGELOGCONTEXT"
+ENV OBJCXXFLAGS="$CXXFLAGS"
 
 RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtbase-everywhere-src-$QT_VERSION.tar.xz") \
  && cd qtbase-everywhere-src-* && mkdir _build && cd _build \
  && ../configure \
     -prefix "$SYSROOT/opt/qt" \
+    -appstore-compliant \
+    -static \
+    -release \
+    -force-asserts \
     -qt-doubleconversion \
     -qt-freetype \
     -qt-harfbuzz \
@@ -561,17 +549,19 @@ RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | 
     -qt-libpng \
     -qt-pcre \
     -qt-zlib \
-    -static \
+    -no-feature-androiddeployqt \
+    -no-feature-brotli \
+    -no-feature-macdeployqt \
+    -no-feature-printsupport \
+    -no-feature-qmake \
+    -no-feature-sql \
     -no-egl \
     -no-glib \
+    -no-opengl \
     -no-vulkan \
-    -no-feature-brotli \
-    -no-feature-printsupport \
-    -no-feature-sql \
     -openssl-linked \
     -nomake examples \
     -nomake tests \
-    -opengl desktop \
     -xcb \
     -- \
     -DCMAKE_FIND_ROOT_PATH="$SYSROOT/usr" \


### PR DESCRIPTION
We don't need it. QtWidgets is not hardware accelerated. OpenGL support is only needed if we do OpenGL stuff ourselves.

Also disabled ubsan again. Qt isn't ubsan-clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/196)
<!-- Reviewable:end -->
