### PR TITLE
chore: Use an ancient toxcore in qtox alpine build.

### DIFF
--- a/qtox/docker/Dockerfile.alpine
+++ b/qtox/docker/Dockerfile.alpine
@@ -31,7 +31,8 @@ RUN ["apk", "add", \
 ENV CC=clang CXX=clang++
 
 WORKDIR /work/c-toxcore
-RUN git clone --recurse-submodules --depth=1 https://github.com/TokTok/c-toxcore /work/c-toxcore \
+RUN git clone --recurse-submodules https://github.com/TokTok/c-toxcore /work/c-toxcore \
+ && git checkout v0.2.12 \
  && cmake -B_build -H. -GNinja \
  && cmake --build _build --target install \
  && rm -rf /work/c-toxcore


### PR DESCRIPTION
This one doesn't build release binaries, so we can use it to see if qtox can still compile against a really old toxcore. 0.2.12 is from 2020.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/198)
<!-- Reviewable:end -->
