### PR TITLE
chore: Update flatpak KDE SDK version to 6.8.

### DIFF
--- a/qtox/docker/Dockerfile.flatpak-builder
+++ b/qtox/docker/Dockerfile.flatpak-builder
@@ -8,10 +8,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get -y --force-yes --no-install-recommends install \
+ appstream-compose \
  ca-certificates \
  ccache \
  curl \
  elfutils \
+ git \
  # flatpak-validate-icon uses gdk-pixbuf which needs an svg loader
  librsvg2-common \
  flatpak \
@@ -21,23 +23,7 @@ RUN apt-get update \
 
 # Pre-download kde flatpak environment to speed up flatpak builds
 RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
- && flatpak --system install flathub -y org.kde.Platform/x86_64/6.7
-
-COPY download/common.sh /build/download/common.sh
-COPY download/download_sodium.sh /build/download/download_sodium.sh
-RUN mkdir -p /src/libsodium && \
-    cd /src/libsodium && \
-    /build/download/download_sodium.sh
-
-COPY download/download_sqlcipher.sh /build/download/download_sqlcipher.sh
-RUN mkdir -p /src/sqlcipher && \
-    cd /src/sqlcipher && \
-    /build/download/download_sqlcipher.sh
-
-COPY download/download_toxcore.sh /build/download/download_toxcore.sh
-RUN mkdir -p /src/toxcore && \
-    cd /src/toxcore && \
-    /build/download/download_toxcore.sh
+ && flatpak --system install flathub -y org.kde.Platform/x86_64/6.8
 
 WORKDIR /qtox
 ENV HOME=/qtox

--- a/qtox/download/download_sodium.sh
+++ b/qtox/download/download_sodium.sh
@@ -17,11 +17,11 @@
 
 set -euo pipefail
 
-SODIUM_VERSION=1.0.20
+SODIUM_VERSION=1.0.20-RELEASE
 SODIUM_HASH=ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19
 
 source "$(dirname "$(realpath "$0")")/common.sh"
 
 download_verify_extract_tarball \
-  "https://github.com/jedisct1/libsodium/releases/download/$SODIUM_VERSION-RELEASE/libsodium-$SODIUM_VERSION.tar.gz" \
+  "https://github.com/jedisct1/libsodium/releases/download/$SODIUM_VERSION/libsodium-${SODIUM_VERSION/-RELEASE/}.tar.gz" \
   "$SODIUM_HASH"


### PR DESCRIPTION
Removed the downloads as well, because now we want to get them from within the manifest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/199)
<!-- Reviewable:end -->
