### PR TITLE
chore: Fix static qtox build.

### DIFF
--- a/qtox/clang-pc-fixer
+++ b/qtox/clang-pc-fixer
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2024 The TokTok team
 import subprocess
 import sys
 from typing import Optional
@@ -18,8 +20,8 @@ def fix_args(args: list[str]) -> list[str]:
     for arg in args:
         fixed_args.append(arg)
         # TODO(iphydf): Get this from pkg-config.
-        if libname(arg) == "GL":
-            fixed_args.extend(("-lglapi", "-lz", "-ldrm", "-lXext"))
+        if libname(arg) == "Qt6Svg":
+            fixed_args.extend(("-lz"))
         elif libname(arg) == "input":
             fixed_args.append("-levdev")
         elif libname(arg) == "xcb":

--- a/qtox/download/download_sodium.sh
+++ b/qtox/download/download_sodium.sh
@@ -1,19 +1,8 @@
 #!/bin/bash
 
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 set -euo pipefail
 

--- a/qtox/download/download_sqlcipher.sh
+++ b/qtox/download/download_sqlcipher.sh
@@ -1,19 +1,8 @@
 #!/bin/bash
 
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 set -euo pipefail
 

--- a/qtox/download/download_toxcore.sh
+++ b/qtox/download/download_toxcore.sh
@@ -1,19 +1,8 @@
 #!/bin/bash
 
-#    Copyright © 2021 by The qTox Project Contributors
-#
-#    This program is libre software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2021 by The qTox Project Contributors
+# Copyright © 2024 The TokTok team
 
 set -euo pipefail
 


### PR DESCRIPTION
We're not linking against libGL anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/203)
<!-- Reviewable:end -->
