### PR TITLE
chore: Add back qmake to host-qt image.

### DIFF
--- a/qtox/docker/Dockerfile.android-builder
+++ b/qtox/docker/Dockerfile.android-builder
@@ -7,7 +7,7 @@ ARG QT_VERSION=6.2.4
 # Build Qt for the host system.
 FROM toxchat/qtox:host-qt_$QT_VERSION AS host-qt
 # Build the rest (including another Qt) for Android.
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 # No Qt from Ubuntu here.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/qtox/docker/Dockerfile.host-qt
+++ b/qtox/docker/Dockerfile.host-qt
@@ -35,7 +35,6 @@ RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | 
     -no-feature-dbus \
     -no-feature-eglfs \
     -no-feature-linuxfb \
-    -no-feature-qmake \
     -no-feature-sharedmemory \
     -no-feature-sql \
     -no-opengl \


### PR DESCRIPTION
We don't need it, but the Android builder image wants it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/213)
<!-- Reviewable:end -->
