### PR TITLE
feat: Add support for asan/tsan/ubsan in macOS Qt build.

### DIFF
--- a/qtox/build_extra_cmake_modules.sh
+++ b/qtox/build_extra_cmake_modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team
@@ -9,12 +9,12 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "extra-cmake-modules" --supported "linux win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "extra-cmake-modules" --supported "linux win32 win64 macos-x86_64 macos-arm64" "$@"
 
 "$SCRIPT_DIR/download/download_extra_cmake_modules.sh"
 
 cmake -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
   -DBUILD_TESTING=OFF \
   -GNinja \
   -B_build \

--- a/qtox/build_ffmpeg.sh
+++ b/qtox/build_ffmpeg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "ffmpeg" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "ffmpeg" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$SCRIPT_ARCH" == "win64" ]; then
   FFMPEG_ARCH="x86_64"

--- a/qtox/build_gdb_windows.sh
+++ b/qtox/build_gdb_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_gmp_windows.sh
+++ b/qtox/build_gmp_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_hunspell.sh
+++ b/qtox/build_hunspell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team
@@ -9,7 +9,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "hunspell" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "hunspell" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   ENABLE_STATIC=--disable-static

--- a/qtox/build_libexif.sh
+++ b/qtox/build_libexif.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "libexif" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "libexif" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   ENABLE_STATIC=--disable-static

--- a/qtox/build_libexpat_windows.sh
+++ b/qtox/build_libexpat_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_mingw_ldd_windows.sh
+++ b/qtox/build_mingw_ldd_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_mpfr_windows.sh
+++ b/qtox/build_mpfr_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_nsisshellexecasuser_windows.sh
+++ b/qtox/build_nsisshellexecasuser_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_openal.sh
+++ b/qtox/build_openal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "openal" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "openal" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$SCRIPT_ARCH" = "win32" ] || [ "$SCRIPT_ARCH" = "win64" ]; then
   "$SCRIPT_DIR/download/download_openal.sh" patched
@@ -37,7 +37,7 @@ export CXXFLAGS="-fPIC -std=c++20"
 cmake \
   "$CMAKE_TOOLCHAIN_FILE" \
   -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_MINIMUM_SUPPORTED_VERSION" \
   -DCMAKE_MACOSX_RPATH="$MACOSX_RPATH" \
   -DALSOFT_UTILS=OFF \

--- a/qtox/build_openssl.sh
+++ b/qtox/build_openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "openssl" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "openssl" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$SCRIPT_ARCH" == "win64" ]; then
   OPENSSL_ARCH="mingw64"
@@ -19,7 +19,7 @@ if [ "$SCRIPT_ARCH" == "win64" ]; then
 elif [ "$SCRIPT_ARCH" == "win32" ]; then
   OPENSSL_ARCH="mingw"
   CROSS_COMPILE_ARCH="--cross-compile-prefix=$MINGW_ARCH-w64-mingw32-"
-elif [ "$SCRIPT_ARCH" == "macos" ] || [ "$SCRIPT_ARCH" == "macos-x86_64" ]; then
+elif [ "$SCRIPT_ARCH" == "macos-x86_64" ]; then
   OPENSSL_ARCH="darwin64-x86_64-cc"
   CROSS_COMPILE_ARCH=""
 elif [ "$SCRIPT_ARCH" == "macos-arm64" ]; then

--- a/qtox/build_opus.sh
+++ b/qtox/build_opus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "opus" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "opus" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   ENABLE_STATIC=--disable-static

--- a/qtox/build_qrencode.sh
+++ b/qtox/build_qrencode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "qrencode" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "qrencode" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   BUILD_SHARED_LIBS=ON
@@ -22,7 +22,7 @@ fi
 "$SCRIPT_DIR/download/download_qrencode.sh"
 
 cmake . \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
   -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_MINIMUM_SUPPORTED_VERSION" \
   "$CMAKE_TOOLCHAIN_FILE" \

--- a/qtox/build_qt_windows.sh
+++ b/qtox/build_qt_windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/build_qtbase_linux.sh
+++ b/qtox/build_qtbase_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/build_qtimageformats_linux.sh
+++ b/qtox/build_qtimageformats_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/build_qtsvg_linux.sh
+++ b/qtox/build_qtsvg_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/build_qttools_linux.sh
+++ b/qtox/build_qttools_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/build_qtwayland_linux.sh
+++ b/qtox/build_qtwayland_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/build_sodium.sh
+++ b/qtox/build_sodium.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "sodium" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "sodium" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   ENABLE_STATIC=--disable-static

--- a/qtox/build_sonnet.sh
+++ b/qtox/build_sonnet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -28,10 +28,9 @@ else
   find . -name CMakeLists.txt -exec sed -i '' -e 's/target_link_libraries(KF6SonnetCore PUBLIC Qt6::Core)/target_link_libraries(KF6SonnetCore PUBLIC Qt6::Core sonnet_hunspell sonnet_nsspellchecker)/' '{}' ';'
 fi
 
-export PATH="$DEP_PREFIX/qt/bin:$PATH"
-"$DEP_PREFIX/qt/bin/qt-cmake" \
+"$QT_PREFIX/bin/qt-cmake" \
   -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
   -DBUILD_SHARED_LIBS="$ENABLE_SHARED" \
   -DBUILD_DESIGNERPLUGIN=OFF \
   -DSONNET_USE_QML=OFF \

--- a/qtox/build_sqlcipher.sh
+++ b/qtox/build_sqlcipher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -13,7 +13,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "sqlcipher" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "sqlcipher" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   ENABLE_STATIC=--disable-static

--- a/qtox/build_static_qtox.sh
+++ b/qtox/build_static_qtox.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 cmake \
   -DCMAKE_TOOLCHAIN_FILE=linux/static-toolchain.cmake \
   -DCMAKE_PREFIX_PATH=/sysroot/opt/qt/lib/cmake \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
   -DSPELL_CHECK=OFF \
   -DUPDATE_CHECK=ON \
   -DSTRICT_OPTIONS=ON \

--- a/qtox/build_toxcore.sh
+++ b/qtox/build_toxcore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "toxcore" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "toxcore" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$LIB_TYPE" = "shared" ]; then
   ENABLE_STATIC=OFF
@@ -32,7 +32,7 @@ build_toxcore() {
   cmake -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
     -DBOOTSTRAP_DAEMON=OFF \
     -DMIN_LOGGER_LEVEL=DEBUG \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
     -DENABLE_STATIC="$ENABLE_STATIC" \
     -DENABLE_SHARED="$ENABLE_SHARED" \
     "$CMAKE_TOOLCHAIN_FILE" \

--- a/qtox/build_toxcore_linux.sh
+++ b/qtox/build_toxcore_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/build_vpx.sh
+++ b/qtox/build_vpx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>
@@ -11,7 +11,7 @@ readonly SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 source "$SCRIPT_DIR/build_utils.sh"
 
-parse_arch --dep "vpx" --supported "win32 win64 macos macos-x86_64 macos-arm64" "$@"
+parse_arch --dep "vpx" --supported "win32 win64 macos-x86_64 macos-arm64" "$@"
 
 if [ "$SCRIPT_ARCH" == "win64" ]; then
   # There is a bug in gcc that breaks avx512 on 64-bit Windows https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
@@ -24,7 +24,7 @@ elif [ "$SCRIPT_ARCH" == "win32" ]; then
   ARCH_FLAGS=""
   CROSS_ARG="$MINGW_ARCH-w64-mingw32-"
   TARGET_ARG="x86-win32-gcc"
-elif [ "$SCRIPT_ARCH" == "macos" ] || [ "$SCRIPT_ARCH" == "macos-x86_64" ]; then
+elif [ "$SCRIPT_ARCH" == "macos-x86_64" ]; then
   ARCH_FLAGS=""
   CROSS_ARG=""
   TARGET_ARG="x86_64-darwin22-gcc" # macOS 13
@@ -63,7 +63,3 @@ CFLAGS="-O2 $ARCH_FLAGS $CROSS_CFLAG" \
 
 make -j "$MAKE_JOBS"
 make install
-
-if [ "$SCRIPT_ARCH" == "macos" ]; then
-  install_name_tool -id '@rpath/libvpx.dylib' "$DEP_PREFIX"/lib/libvpx.dylib
-fi

--- a/qtox/build_zstd.sh
+++ b/qtox/build_zstd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team
@@ -22,7 +22,7 @@ fi
 "$SCRIPT_DIR/download/download_zstd.sh"
 
 cmake -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
   -DZSTD_BUILD_STATIC="$ENABLE_STATIC" \
   -DZSTD_BUILD_SHARED="$ENABLE_SHARED" \
   -DBUILD_SHARED_LIBS="$ENABLE_SHARED" \

--- a/qtox/docker/Dockerfile.alpine-appimage
+++ b/qtox/docker/Dockerfile.alpine-appimage
@@ -42,65 +42,67 @@ ENV CC=clang CXX=clang++
 
 ARG SCRIPT_ARCH=linux
 
-COPY download/common.sh /build/download/common.sh
-COPY build_utils.sh /build/build_utils.sh
+COPY download/common.sh /build/download/
+COPY build_utils.sh /build/
 
-COPY download/download_qtbase.sh /build/download/download_qtbase.sh
-COPY build_qtbase_linux.sh /build/build_qtbase_linux.sh
+COPY download/version_qt.sh /build/download/
+
+COPY download/download_qtbase.sh /build/download/
+COPY build_qtbase_linux.sh /build/
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
   /build/build_qtbase_linux.sh --arch ${SCRIPT_ARCH} --libtype shared && \
   rm -fr /src/qt
 
-COPY download/download_qttools.sh /build/download/download_qttools.sh
-COPY build_qttools_linux.sh /build/build_qttools_linux.sh
+COPY download/download_qttools.sh /build/download/
+COPY build_qttools_linux.sh /build/
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
   /build/build_qttools_linux.sh --arch ${SCRIPT_ARCH} --libtype shared && \
   rm -fr /src/qt
 
-COPY download/download_qtsvg.sh /build/download/download_qtsvg.sh
-COPY build_qtsvg_linux.sh /build/build_qtsvg_linux.sh
+COPY download/download_qtsvg.sh /build/download/
+COPY build_qtsvg_linux.sh /build/
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
   /build/build_qtsvg_linux.sh --arch ${SCRIPT_ARCH} --libtype shared && \
   rm -fr /src/qt
 
-COPY download/download_qtimageformats.sh /build/download/download_qtimageformats.sh
-COPY build_qtimageformats_linux.sh /build/build_qtimageformats_linux.sh
+COPY download/download_qtimageformats.sh /build/download/
+COPY build_qtimageformats_linux.sh /build/
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
   /build/build_qtimageformats_linux.sh --arch ${SCRIPT_ARCH} --libtype shared && \
   rm -fr /src/qt
 
-COPY download/download_qtwayland.sh /build/download/download_qtwayland.sh
-COPY build_qtwayland_linux.sh /build/build_qtwayland_linux.sh
+COPY download/download_qtwayland.sh /build/download/
+COPY build_qtwayland_linux.sh /build/
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
   /build/build_qtwayland_linux.sh --arch ${SCRIPT_ARCH} --libtype shared && \
   rm -fr /src/qt
 
-COPY download/download_extra_cmake_modules.sh /build/download/download_extra_cmake_modules.sh
-COPY build_extra_cmake_modules.sh /build/build_extra_cmake_modules.sh
+COPY download/download_extra_cmake_modules.sh /build/download/
+COPY build_extra_cmake_modules.sh /build/
 RUN mkdir -p /src/tox && \
     cd /src/tox && \
     /build/build_extra_cmake_modules.sh --arch ${SCRIPT_ARCH} && \
     rm -fr /src/tox
 
-COPY download/download_sonnet.sh /build/download/download_sonnet.sh
-COPY build_sonnet.sh /build/build_sonnet.sh
+COPY download/download_sonnet.sh /build/download/
+COPY build_sonnet.sh /build/
 RUN mkdir -p /src/tox && \
     cd /src/tox && \
     /build/build_sonnet.sh && \
     rm -fr /src/tox
 
-COPY download/download_toxcore.sh /build/download/download_toxcore.sh
-COPY build_toxcore_linux.sh /build/build_toxcore_linux.sh
+COPY download/download_toxcore.sh /build/download/
+COPY build_toxcore_linux.sh /build/
 RUN mkdir -p /src/tox && \
     cd /src/tox && \
     /build/build_toxcore_linux.sh && \

--- a/qtox/docker/Dockerfile.alpine-static
+++ b/qtox/docker/Dockerfile.alpine-static
@@ -529,12 +529,13 @@ COPY --from=build-zstd $SYSROOT/usr $SYSROOT/usr
 
 FROM build-x11 AS build-qt
 
-ARG QT_VERSION=6.8.1
-
 ENV CXXFLAGS="-DQT_MESSAGELOGCONTEXT"
 ENV OBJCXXFLAGS="$CXXFLAGS"
 
-RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtbase-everywhere-src-$QT_VERSION.tar.xz") \
+COPY download/version_qt.sh /work/
+
+RUN . /work/version_qt.sh \
+ && tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtbase-everywhere-src-$QT_VERSION.tar.xz") \
  && mv qtbase-everywhere-src-* qtbase && mkdir qtbase/_build && cd qtbase/_build \
  && ../configure \
     -prefix "$SYSROOT/opt/qt" \
@@ -574,7 +575,8 @@ RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | 
  && cmake --install . \
  && rm -rf /work/build
 
-RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qttools-everywhere-src-$QT_VERSION.tar.xz") \
+RUN . /work/version_qt.sh \
+ && tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qttools-everywhere-src-$QT_VERSION.tar.xz") \
  && mv qttools-everywhere-src-* qttools && mkdir qttools/_build && cd qttools/_build \
  && "$SYSROOT/opt/qt/bin/qt-configure-module" .. \
     -no-feature-assistant \
@@ -596,7 +598,8 @@ RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | 
  && cmake --install . \
  && rm -rf /work/build
 
-RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtsvg-everywhere-src-$QT_VERSION.tar.xz") \
+RUN . /work/version_qt.sh \
+ && tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtsvg-everywhere-src-$QT_VERSION.tar.xz") \
  && mv qtsvg-everywhere-src-* qtsvg && mkdir qtsvg/_build && cd qtsvg/_build \
  && "$SYSROOT/opt/qt/bin/qt-configure-module" .. \
     -- \
@@ -608,7 +611,8 @@ RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | 
  && cmake --install . \
  && rm -rf /work/build
 
-RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtimageformats-everywhere-src-$QT_VERSION.tar.xz") \
+RUN . /work/version_qt.sh \
+ && tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtimageformats-everywhere-src-$QT_VERSION.tar.xz") \
  && mv qtimageformats-everywhere-src-* qtimageformats && mkdir qtimageformats/_build && cd qtimageformats/_build \
  && "$SYSROOT/opt/qt/bin/qt-configure-module" .. \
     -- \
@@ -620,7 +624,8 @@ RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | 
  && cmake --install . \
  && rm -rf /work/build
 
-RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtwayland-everywhere-src-$QT_VERSION.tar.xz") \
+RUN . /work/version_qt.sh \
+ && tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtwayland-everywhere-src-$QT_VERSION.tar.xz") \
  && mv qtwayland-everywhere-src-* qtwayland && mkdir qtwayland/_build && cd qtwayland/_build \
  && "$SYSROOT/opt/qt/bin/qt-configure-module" .. \
     -- \

--- a/qtox/docker/Dockerfile.android-builder
+++ b/qtox/docker/Dockerfile.android-builder
@@ -2,7 +2,6 @@
 # Copyright © 2024 The TokTok team
 
 ARG QT_VERSION=6.2.4
-#ARG QT_VERSION=6.8.1
 
 # Build Qt for the host system.
 FROM toxchat/qtox:host-qt_$QT_VERSION AS host-qt
@@ -53,7 +52,6 @@ RUN yes | sdkmanager --licenses || true
 RUN ["sdkmanager", "platform-tools", "platforms;android-34", "build-tools;34.0.0"]
 
 ARG NDK_VERSION=21.3.6528147
-#ARG NDK_VERSION=26.1.10909125
 RUN sdkmanager "ndk;$NDK_VERSION"
 
 ENV ANDROID_NDK_ROOT=$ANDROID_SDK_HOME/ndk/$NDK_VERSION
@@ -63,16 +61,12 @@ ENV SYSROOT=$TOOLCHAIN/sysroot
 ENV PKG_CONFIG_PATH=$SYSROOT/usr/lib/pkgconfig
 
 ARG ANDROID_API=24
-#ARG ANDROID_API=26
 
-#ARG ANDROID_ABI=armeabi-v7a
 ARG ANDROID_ABI=arm64-v8a
 
 # OpenSSL
 #FROM base AS build-openssl
 
-#ARG ANDROID_OPENSSL_ABI=arm
-#ARG ANDROID_OPENSSL_ASM=-no-asm
 ARG ANDROID_OPENSSL_ABI=arm64
 ARG ANDROID_OPENSSL_ASM=
 RUN tar zxf <(wget -O- https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz) \
@@ -108,11 +102,9 @@ RUN tar zxf <(wget -O- https://github.com/facebook/zstd/releases/download/v1.5.6
 #COPY --from=build-zstd $SYSROOT/usr $SYSROOT/usr
 COPY --from=host-qt /work/host /work/host
 
-#ARG QT_BUILD_TYPE=debug
 ARG QT_BUILD_TYPE=release
 
 ARG QT_VERSION=6.2.4
-#ARG QT_VERSION=6.8.1
 
 RUN tar Jxf <(wget -O- "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtbase-everywhere-src-$QT_VERSION.tar.xz") \
  && sed -i -e 's!# *define QLOGGING_HAVE_BACKTRACE!//&!' qtbase-everywhere-src-*/src/corelib/global/qlogging.cpp \
@@ -156,7 +148,6 @@ RUN tar Jxf <(wget -O- "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" |
 # Base for the rest of the builds
 #FROM base AS build-base
 
-#ARG ANDROID_TRIPLE=armv7a-linux-androideabi
 ARG ANDROID_TRIPLE=aarch64-linux-android
 ENV ANDROID_TRIPLE_API=$ANDROID_TRIPLE$ANDROID_API
 ENV CC=$TOOLCHAIN/bin/$ANDROID_TRIPLE_API-clang \
@@ -165,7 +156,6 @@ ENV CC=$TOOLCHAIN/bin/$ANDROID_TRIPLE_API-clang \
 # ffmpeg
 #FROM build-base AS build-ffmpeg
 
-#ARG ANDROID_FFMPEG_ABI=armv7a
 ARG ANDROID_FFMPEG_ABI=arm64
 RUN tar Jxf <(wget -O- https://www.ffmpeg.org/releases/ffmpeg-7.1.tar.xz) \
  && cd ffmpeg-7.1 \
@@ -273,7 +263,6 @@ RUN tar zxf <(wget -O- https://github.com/xiph/opus/releases/download/v1.5.2/opu
 # libvpx
 #FROM build-base AS build-libvpx
 
-#ARG ANDROID_VPX_ABI=armv7-android-gcc
 ARG ANDROID_VPX_ABI=arm64-android-gcc
 RUN tar zxf <(wget -O- https://github.com/webmproject/libvpx/archive/refs/tags/v1.15.0.tar.gz) \
  && cd libvpx-1.15.0 \

--- a/qtox/docker/Dockerfile.host-qt
+++ b/qtox/docker/Dockerfile.host-qt
@@ -24,7 +24,6 @@ WORKDIR /work/build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG QT_VERSION=6.2.4
-#ARG QT_VERSION=6.8.1
 
 RUN tar Jxf <(curl -L "https://download.qt.io/archive/qt/$(echo "$QT_VERSION" | grep -o '...')/$QT_VERSION/submodules/qtbase-everywhere-src-$QT_VERSION.tar.xz") \
  && cd qtbase-everywhere-src-* && mkdir _build && cd _build \

--- a/qtox/docker/Dockerfile.windows-builder
+++ b/qtox/docker/Dockerfile.windows-builder
@@ -52,11 +52,11 @@ RUN update-alternatives --set ${ARCH}-w64-mingw32-gcc /usr/bin/${ARCH}-w64-mingw
 
 COPY toolchain/windows-${ARCH}-toolchain.cmake /build/windows-toolchain.cmake
 
-COPY download/common.sh /build/download/common.sh
-COPY build_utils.sh /build/build_utils.sh
+COPY download/common.sh /build/download/
+COPY build_utils.sh /build/
 
-COPY download/download_openssl.sh /build/download/download_openssl.sh
-COPY build_openssl.sh /build/build_openssl.sh
+COPY download/download_openssl.sh /build/download/
+COPY build_openssl.sh /build/
 
 RUN mkdir -p /src/openssl && \
   cd /src/openssl && \
@@ -65,67 +65,67 @@ RUN mkdir -p /src/openssl && \
 
 FROM base AS non-qt
 
-COPY download/download_sqlcipher.sh /build/download/download_sqlcipher.sh
-COPY build_sqlcipher.sh /build/build_sqlcipher.sh
+COPY download/download_sqlcipher.sh /build/download/
+COPY build_sqlcipher.sh /build/
 
 RUN mkdir -p /src/sqlcipher && \
   cd /src/sqlcipher && \
   /build/build_sqlcipher.sh  --arch ${SCRIPT_ARCH} && \
   rm -fr /src/sqlcipher
 
-COPY download/download_ffmpeg.sh /build/download/download_ffmpeg.sh
-COPY build_ffmpeg.sh /build/build_ffmpeg.sh
+COPY download/download_ffmpeg.sh /build/download/
+COPY build_ffmpeg.sh /build/
 RUN mkdir -p /src/ffmpeg && \
   cd /src/ffmpeg && \
   /build/build_ffmpeg.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/ffmpeg
 
-COPY download/download_openal.sh /build/download/download_openal.sh
-COPY build_openal.sh /build/build_openal.sh
-COPY patches/openal-cmake-3-11.patch /build/patches/openal-cmake-3-11.patch
+COPY download/download_openal.sh /build/download/
+COPY build_openal.sh /build/
+COPY patches/openal-cmake-3-11.patch /build/patches/
 
 RUN mkdir -p /src/openal && \
   cd /src/openal && \
   /build/build_openal.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/openal
 
-COPY download/download_qrencode.sh /build/download/download_qrencode.sh
-COPY build_qrencode.sh /build/build_qrencode.sh
+COPY download/download_qrencode.sh /build/download/
+COPY build_qrencode.sh /build/
 RUN mkdir -p /src/qrencode && \
   cd /src/qrencode && \
   /build/build_qrencode.sh  --arch ${SCRIPT_ARCH} && \
   rm -fr /src/qrencode
 
-COPY download/download_libexif.sh /build/download/download_libexif.sh
-COPY build_libexif.sh /build/build_libexif.sh
+COPY download/download_libexif.sh /build/download/
+COPY build_libexif.sh /build/
 RUN mkdir -p /src/exif && \
   cd /src/exif && \
   /build/build_libexif.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/exif
 
-COPY download/download_opus.sh /build/download/download_opus.sh
-COPY build_opus.sh /build/build_opus.sh
+COPY download/download_opus.sh /build/download/
+COPY build_opus.sh /build/
 RUN mkdir -p /src/opus && \
   cd /src/opus && \
   /build/build_opus.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/opus
 
-COPY download/download_sodium.sh /build/download/download_sodium.sh
-COPY build_sodium.sh /build/build_sodium.sh
+COPY download/download_sodium.sh /build/download/
+COPY build_sodium.sh /build/
 RUN mkdir -p /src/sodium && \
   cd /src/sodium && \
   /build/build_sodium.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/sodium
 
-COPY download/download_vpx.sh /build/download/download_vpx.sh
-COPY build_vpx.sh /build/build_vpx.sh
+COPY download/download_vpx.sh /build/download/
+COPY build_vpx.sh /build/
 RUN mkdir -p /src/vpx && \
   cd /src/vpx && \
   /build/build_vpx.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/vpx
 
-COPY download/download_toxcore.sh /build/download/download_toxcore.sh
-COPY build_toxcore.sh /build/build_toxcore.sh
+COPY download/download_toxcore.sh /build/download/
+COPY build_toxcore.sh /build/
 RUN mkdir -p /src/tox && \
   cd /src/tox && \
   /build/build_toxcore.sh && \
@@ -135,7 +135,7 @@ FROM base as debug-export
 
 RUN mkdir -p /debug_export
 
-COPY download/download_mingw_debug_scripts.sh /build/download/download_mingw_debug_scripts.sh
+COPY download/download_mingw_debug_scripts.sh /build/download/
 RUN mkdir -p /src/mingw-debug-scripts && \
   cd /src/mingw-debug-scripts && \
   /build/download/download_mingw_debug_scripts.sh  && \
@@ -143,29 +143,29 @@ RUN mkdir -p /src/mingw-debug-scripts && \
   cp -a debug-*.bat /debug_export && \
   rm -fr /src/mingw-debug-scripts
 
-COPY download/download_gmp.sh /build/download/download_gmp.sh
-COPY build_gmp_windows.sh /build/build_gmp_windows.sh
+COPY download/download_gmp.sh /build/download/
+COPY build_gmp_windows.sh /build/
 RUN  mkdir -p /src/gmp && \
   cd /src/gmp && \
   /build/build_gmp_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/gmp
 
-COPY download/download_libexpat.sh /build/download/download_libexpat.sh
-COPY build_libexpat_windows.sh /build/build_libexpat_windows.sh
+COPY download/download_libexpat.sh /build/download/
+COPY build_libexpat_windows.sh /build/
 RUN mkdir -p /src/libexpat && \
   cd /src/libexpat && \
   /build/build_libexpat_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/libexpat
 
-COPY download/download_mpfr.sh /build/download/download_mpfr.sh
-COPY build_mpfr_windows.sh /build/build_mpfr_windows.sh
+COPY download/download_mpfr.sh /build/download/
+COPY build_mpfr_windows.sh /build/
 RUN  mkdir -p /src/mpfr && \
   cd /src/mpfr && \
   /build/build_mpfr_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/mpfr
 
-COPY download/download_gdb.sh /build/download/download_gdb.sh
-COPY build_gdb_windows.sh /build/build_gdb_windows.sh
+COPY download/download_gdb.sh /build/download/
+COPY build_gdb_windows.sh /build/
 RUN mkdir -p /src/gdb && \
   cd /src/gdb && \
   /build/build_gdb_windows.sh --arch ${SCRIPT_ARCH} && \
@@ -174,31 +174,33 @@ RUN mkdir -p /src/gdb && \
 
 FROM base as qt
 
-COPY download/download_zstd.sh /build/download/download_zstd.sh
-COPY build_zstd.sh /build/build_zstd.sh
+COPY download/download_zstd.sh /build/download/
+COPY build_zstd.sh /build/
 
 RUN mkdir -p /src/zstd && \
   cd /src/zstd && \
   /build/build_zstd.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/zstd
 
-COPY download/download_qt.sh /build/download/download_qt.sh
-COPY build_qt_windows.sh /build/build_qt_windows.sh
+COPY download/version_qt.sh /build/download/
+
+COPY download/download_qt.sh /build/download/
+COPY build_qt_windows.sh /build/
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
   /build/build_qt_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/qt
 
-COPY download/download_nsisshellexecasuser.sh /build/download/download_nsisshellexecasuser.sh
-COPY build_nsisshellexecasuser_windows.sh /build/build_nsisshellexecasuser_windows.sh
+COPY download/download_nsisshellexecasuser.sh /build/download/
+COPY build_nsisshellexecasuser_windows.sh /build/
 RUN mkdir -p /src/nsisshellexecasuser && \
   cd /src/nsisshellexecasuser && \
   /build/build_nsisshellexecasuser_windows.sh && \
   rm -fr /src/nsisshellexecasuser
 
-COPY download/download_mingw_ldd.sh /build/download/download_mingw_ldd.sh
-COPY build_mingw_ldd_windows.sh /build/build_mingw_ldd_windows.sh
+COPY download/download_mingw_ldd.sh /build/download/
+COPY build_mingw_ldd_windows.sh /build/
 RUN mkdir -p /src/mingw_ldd && \
   cd /src/mingw_ldd && \
   /build/build_mingw_ldd_windows.sh && \

--- a/qtox/download/common.sh
+++ b/qtox/download/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 #     Copyright (c) 2017-2021 Maxim Biro <nurupo.contributions@gmail.com>

--- a/qtox/download/download_extra_cmake_modules.sh
+++ b/qtox/download/download_extra_cmake_modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/download/download_ffmpeg.sh
+++ b/qtox/download/download_ffmpeg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_gdb.sh
+++ b/qtox/download/download_gdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_gmp.sh
+++ b/qtox/download/download_gmp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_hunspell.sh
+++ b/qtox/download/download_hunspell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/download/download_libexif.sh
+++ b/qtox/download/download_libexif.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_libexpat.sh
+++ b/qtox/download/download_libexpat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_mingw_debug_scripts.sh
+++ b/qtox/download/download_mingw_debug_scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_mingw_ldd.sh
+++ b/qtox/download/download_mingw_ldd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_mpfr.sh
+++ b/qtox/download/download_mpfr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_nsisshellexecasuser.sh
+++ b/qtox/download/download_nsisshellexecasuser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_openal.sh
+++ b/qtox/download/download_openal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later AND MIT
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_openssl.sh
+++ b/qtox/download/download_openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_opus.sh
+++ b/qtox/download/download_opus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_qrencode.sh
+++ b/qtox/download/download_qrencode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_qt.sh
+++ b/qtox/download/download_qt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors
@@ -6,15 +6,13 @@
 
 set -euo pipefail
 
-QT_MAJOR=6
-QT_MINOR=8
-QT_PATCH=1
 QTBASE_HASH=40b14562ef3bd779bc0e0418ea2ae08fa28235f8ea6e8c0cb3bce1d6ad58dcaf
 QTTOOLS_HASH=9d43d409be08b8681a0155a9c65114b69c9a3fc11aef6487bb7fdc5b283c432d
 QTSVG_HASH=3d0de73596e36b2daa7c48d77c4426bb091752856912fba720215f756c560dd0
 QTIMAGEFORMATS_HASH=138cc2909aa98f5ff7283e36eb3936eb5e625d3ca3b4febae2ca21d8903dd237
 
 source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(dirname "$(realpath "$0")")/version_qt.sh"
 
 MIRROR=http://master.qt-project.org
 

--- a/qtox/download/download_qtbase.sh
+++ b/qtox/download/download_qtbase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors
@@ -6,12 +6,10 @@
 
 set -euo pipefail
 
-QT_MAJOR=6
-QT_MINOR=8
-QT_PATCH=1
 QTBASE_HASH=40b14562ef3bd779bc0e0418ea2ae08fa28235f8ea6e8c0cb3bce1d6ad58dcaf
 
 source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(dirname "$(realpath "$0")")/version_qt.sh"
 
 MIRROR=http://master.qt-project.org
 

--- a/qtox/download/download_qtimageformats.sh
+++ b/qtox/download/download_qtimageformats.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors
@@ -6,12 +6,10 @@
 
 set -euo pipefail
 
-QT_MAJOR=6
-QT_MINOR=8
-QT_PATCH=1
 QTIMAGEFORMATS_HASH=138cc2909aa98f5ff7283e36eb3936eb5e625d3ca3b4febae2ca21d8903dd237
 
 source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(dirname "$(realpath "$0")")/version_qt.sh"
 
 MIRROR=http://master.qt-project.org
 

--- a/qtox/download/download_qtsvg.sh
+++ b/qtox/download/download_qtsvg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors
@@ -6,12 +6,10 @@
 
 set -euo pipefail
 
-QT_MAJOR=6
-QT_MINOR=8
-QT_PATCH=1
 QTSVG_HASH=3d0de73596e36b2daa7c48d77c4426bb091752856912fba720215f756c560dd0
 
 source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(dirname "$(realpath "$0")")/version_qt.sh"
 
 MIRROR=http://master.qt-project.org
 

--- a/qtox/download/download_qttools.sh
+++ b/qtox/download/download_qttools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors
@@ -6,12 +6,10 @@
 
 set -euo pipefail
 
-QT_MAJOR=6
-QT_MINOR=8
-QT_PATCH=1
 QTTOOLS_HASH=9d43d409be08b8681a0155a9c65114b69c9a3fc11aef6487bb7fdc5b283c432d
 
 source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(dirname "$(realpath "$0")")/version_qt.sh"
 
 MIRROR=http://master.qt-project.org
 

--- a/qtox/download/download_qtwayland.sh
+++ b/qtox/download/download_qtwayland.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors
@@ -6,12 +6,10 @@
 
 set -euo pipefail
 
-QT_MAJOR=6
-QT_MINOR=8
-QT_PATCH=1
 QTWAYLAND_HASH=2226fbde4e2ddd12f8bf4b239c8f38fd706a54e789e63467dfddc77129eca203
 
 source "$(dirname "$(realpath "$0")")/common.sh"
+source "$(dirname "$(realpath "$0")")/version_qt.sh"
 
 MIRROR=http://master.qt-project.org
 

--- a/qtox/download/download_sodium.sh
+++ b/qtox/download/download_sodium.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_sonnet.sh
+++ b/qtox/download/download_sonnet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/download/download_sqlcipher.sh
+++ b/qtox/download/download_sqlcipher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_toxcore.sh
+++ b/qtox/download/download_toxcore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_vpx.sh
+++ b/qtox/download/download_vpx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2021 by The qTox Project Contributors

--- a/qtox/download/download_zstd.sh
+++ b/qtox/download/download_zstd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright © 2024 The TokTok team

--- a/qtox/download/version_qt.sh
+++ b/qtox/download/version_qt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2024 The TokTok team
+
+QT_VERSION="6.8.1"
+QT_MAJOR=6
+QT_MINOR=8
+QT_PATCH=1


### PR DESCRIPTION
Also factored out the Qt version so it only needs to be changed in 3 places when we upgrade to the next version: `version_qt.sh`, GitHub workflows, and the windows builder image (for its `FROM` directive).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/220)
<!-- Reviewable:end -->
