### PR TITLE
chore: Upgrade minimum toxcore version to 0.2.14.

### DIFF
--- a/qtox/docker/Dockerfile.alpine
+++ b/qtox/docker/Dockerfile.alpine
@@ -31,11 +31,11 @@ RUN ["apk", "add", \
 ENV CC=clang CXX=clang++
 
 WORKDIR /work/c-toxcore
-# We use toxcore v0.2.12 here to test qTox builds against an old toxcore version.
+# We use toxcore v0.2.14 here to test qTox builds against an old toxcore version.
 # qTox normally uses the most recent toxcore version, but wants to remain
 # compatible with older versions present in Linux distributions.
 RUN git clone --recurse-submodules https://github.com/TokTok/c-toxcore /work/c-toxcore \
- && git checkout v0.2.12 \
+ && git checkout v0.2.14 \
  && cmake -B_build -H. -GNinja \
  && cmake --build _build --target install \
  && rm -rf /work/c-toxcore


### PR DESCRIPTION
We need Tox_File_Kind (which used to be TOX_FILE_KIND).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/221)
<!-- Reviewable:end -->
