### PR TITLE
chore: Make local development a bit easier against toxcore.

### DIFF
--- a/qtox/build_toxcore.sh
+++ b/qtox/build_toxcore.sh
@@ -22,12 +22,16 @@ else
 fi
 
 build_toxcore() {
-  TOXCORE_SRC="$(realpath .)/toxcore"
+  if [ -d "../../../c-toxcore" ]; then
+    pushd "../../../c-toxcore" >/dev/null || exit 1
+  else
+    TOXCORE_SRC="$(realpath .)/toxcore"
 
-  mkdir -p "$TOXCORE_SRC"
-  pushd "$TOXCORE_SRC" >/dev/null || exit 1
+    mkdir -p "$TOXCORE_SRC"
+    pushd "$TOXCORE_SRC" >/dev/null || exit 1
 
-  "$SCRIPT_DIR/download/download_toxcore.sh"
+    "$SCRIPT_DIR/download/download_toxcore.sh"
+  fi
 
   cmake -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
     -DBOOTSTRAP_DAEMON=OFF \


### PR DESCRIPTION
If a local version of c-toxcore is located in the place toktok-stack puts it, then use that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/223)
<!-- Reviewable:end -->
