### PR TITLE
feat: Add a deploy build for the wasm toolchain.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -233,3 +233,41 @@ jobs:
           cache-from: type=registry,ref=toxchat/qtox:android-builder.${{ matrix.arch }}.${{ matrix.build_type }}_${{ matrix.version }}
           cache-to: type=inline
           push: ${{ github.event_name == 'push' }}
+
+  update-nightly-tag:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Move nightly tag to head for nightly release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: git tag -f nightly && git push origin nightly -f
+
+  deploy-qtox-wasm-buildhome:
+    # Extracts /opt/buildhome from the qtox:wasm-builder image and puts it into
+    # a nightly release artifact.
+    needs: [update-nightly-tag, qtox]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch wasm-builder image
+        run: docker pull toxchat/qtox:wasm-builder
+      - name: Extract /opt/buildhome from wasm-builder
+        run: docker run --rm --entrypoint tar toxchat/qtox:wasm-builder -c -C /opt buildhome > qtox-wasm-buildhome.tar
+      - name: Compress nightly release artifact
+        run: |
+          ls -lh qtox-wasm-buildhome.tar
+          gzip qtox-wasm-buildhome.tar
+          ls -lh qtox-wasm-buildhome.tar.gz
+      - name: Upload nightly release artifact
+        if: github.event_name == 'push'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          tag: nightly
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: qtox-wasm-buildhome.tar.gz

--- a/qtox/docker/Dockerfile.wasm-builder
+++ b/qtox/docker/Dockerfile.wasm-builder
@@ -118,7 +118,7 @@ RUN mkdir -p /src/toxcore \
  && /build/build_toxcore.sh \
  && rm -fr /src/toxcore
 
-FROM base as qt
+FROM base AS qt
 
 COPY download/download_zstd.sh /build/download/
 COPY build_zstd.sh /build/

--- a/qtox/docker/Dockerfile.windows-builder
+++ b/qtox/docker/Dockerfile.windows-builder
@@ -133,7 +133,7 @@ RUN mkdir -p /src/toxcore \
  && /build/build_toxcore.sh \
  && rm -fr /src/toxcore
 
-FROM base as debug-export
+FROM base AS debug-export
 
 RUN mkdir -p /debug_export
 
@@ -174,7 +174,7 @@ RUN mkdir -p /src/gdb \
  && rm -fr /src/gdb \
  && cp /windows/bin/gdb.exe /debug_export/gdb.exe
 
-FROM base as qt
+FROM base AS qt
 
 COPY download/download_zstd.sh /build/download/
 COPY build_zstd.sh /build/


### PR DESCRIPTION
So we can download it somewhere that doesn't support docker and use it there to build qtox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/244)
<!-- Reviewable:end -->
