### PR TITLE
fix: Enable sanitizer on toxcore when requested.

### DIFF
--- a/qtox/build_toxcore.sh
+++ b/qtox/build_toxcore.sh
@@ -38,7 +38,14 @@ else
   "$SCRIPT_DIR/download/download_toxcore.sh"
 fi
 
-"${EMCMAKE[@]}" cmake -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
+if [ -n "$SANITIZE" ]; then
+  export CFLAGS="-fsanitize=$CLANG_SANITIZER"
+  export CXXFLAGS="-fsanitize=$CLANG_SANITIZER"
+  CMAKE_BUILD_TYPE=Debug
+fi
+
+"${EMCMAKE[@]}" cmake \
+  -DCMAKE_INSTALL_PREFIX="$DEP_PREFIX" \
   -DBOOTSTRAP_DAEMON=OFF \
   -DEXPERIMENTAL_API=ON \
   -DMIN_LOGGER_LEVEL="$MIN_LOGGER_LEVEL" \


### PR DESCRIPTION
We enable it on qt but no other dependencies at the moment (we probably should). This fixes it at least for toxcore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/246)
<!-- Reviewable:end -->
