### PR TITLE
chore: Add tcl download file for qtox.

### DIFF
--- a/qtox/download/download_tcl.sh
+++ b/qtox/download/download_tcl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright © 2025 The TokTok team
+
+set -euo pipefail
+
+TCL_VERSION=8.6.10
+TCL_HASH=5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed
+
+source "$(dirname "$(realpath "$0")")/common.sh"
+
+download_verify_extract_tarball \
+  "https://downloads.sourceforge.net/project/tcl/Tcl/$TCL_VERSION/tcl$TCL_VERSION-src.tar.gz" \
+  "$TCL_HASH"


### PR DESCRIPTION
We don't use it, but this way we can control the TCL version in the flatpak descriptor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/253)
<!-- Reviewable:end -->
