### PR TITLE
fix: Don't error when passing too new warning flags to old clang.

### DIFF
--- a/qtox/build_qtbase_macos.sh
+++ b/qtox/build_qtbase_macos.sh
@@ -45,7 +45,7 @@ fi
 
 # We want -Werror to catch warnings related to macOS version compatibility.
 # We silence unused-variable because disabling features (like filesystemwatcher) can leave variables unused in Qt's source.
-sed -i '' -e 's/-Wextra/-Wextra -Werror "-Wno-#warnings" -Wno-cast-function-type-mismatch -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-unused-variable -Wno-vla-cxx-extension/' cmake/QtCompilerFlags.cmake
+sed -i '' -e 's/-Wextra/-Wextra -Werror -Wno-unknown-warning-option "-Wno-#warnings" -Wno-cast-function-type-mismatch -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-unused-variable -Wno-vla-cxx-extension/' cmake/QtCompilerFlags.cmake
 
 mkdir _build && pushd _build
 ../configure \


### PR DESCRIPTION
Older macOS versions with older xcode versions with older clang versions don't have these warning flags. On newer ones, we do need those suppressions. Alternative would be to detect support, but in this case, we don't really care to be extremely clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/270)
<!-- Reviewable:end -->
