### PR TITLE
feat: Add Raspberry Pi cross compilation images for qtox.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,6 +132,8 @@ jobs:
           - alpine-appimage
           - alpine-static
           - debian
+          - debian-pi-cross-armhf
+          - debian-pi-cross-arm64
           - fedora
           - flatpak-builder
           - ubuntu-lts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,12 @@ services:
   debian:
     image: ghcr.io/toktok/qtox:debian
     <<: *shared_params
+  debian-pi-cross-armhf:
+    image: ghcr.io/toktok/qtox:debian-pi-cross-armhf
+    <<: *shared_params
+  debian-pi-cross-arm64:
+    image: ghcr.io/toktok/qtox:debian-pi-cross-arm64
+    <<: *shared_params
   fedora:
     image: ghcr.io/toktok/qtox:fedora
     <<: *shared_params

--- a/qtox/docker/Dockerfile.debian-pi-cross-arm64
+++ b/qtox/docker/Dockerfile.debian-pi-cross-arm64
@@ -1,0 +1,54 @@
+# Dockerfile.debian-pi-cross-arm64
+# Cross-compilation environment for Raspberry Pi (ARM64) based on Debian Bookworm
+
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN dpkg --add-architecture arm64 && \
+    apt-get update
+
+# Install native amd64 build tools
+RUN apt-get install -y --no-install-recommends \
+    build-essential \
+    crossbuild-essential-arm64 \
+    cmake \
+    git \
+    pkg-config \
+    ninja-build \
+    dpkg-dev \
+    debhelper \
+    qt6-base-dev \
+    qt6-tools-dev \
+    qt6-tools-dev-tools \
+    ca-certificates
+
+# Install target dependencies for arm64
+RUN apt-get install -y --no-install-recommends \
+    pkg-config:arm64 \
+    qt6-base-dev:arm64 \
+    libqt6svg6-dev:arm64 \
+    qt6-tools-dev:arm64 \
+    libavcodec-dev:arm64 \
+    libavdevice-dev:arm64 \
+    libavformat-dev:arm64 \
+    libavutil-dev:arm64 \
+    libswscale-dev:arm64 \
+    libexif-dev:arm64 \
+    libqrencode-dev:arm64 \
+    libsqlcipher-dev:arm64 \
+    libssl-dev:arm64 \
+    libtoxcore-dev:arm64 \
+    libsodium-dev:arm64 \
+    libopus-dev:arm64 \
+    libvpx-dev:arm64 \
+    libopenal-dev:arm64 \
+    libv4l-dev:arm64 \
+    libx11-dev:arm64 \
+    libxss-dev:arm64 \
+    libunwind-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/qtox/docker/Dockerfile.debian-pi-cross-armhf
+++ b/qtox/docker/Dockerfile.debian-pi-cross-armhf
@@ -1,0 +1,54 @@
+# Dockerfile.debian-pi-cross-armhf
+# Cross-compilation environment for Raspberry Pi (ARMHF) based on Debian Bookworm
+
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN dpkg --add-architecture armhf && \
+    apt-get update
+
+# Install native amd64 build tools
+RUN apt-get install -y --no-install-recommends \
+    build-essential \
+    crossbuild-essential-armhf \
+    cmake \
+    git \
+    pkg-config \
+    ninja-build \
+    dpkg-dev \
+    debhelper \
+    qt6-base-dev \
+    qt6-tools-dev \
+    qt6-tools-dev-tools \
+    ca-certificates
+
+# Install target dependencies for armhf
+RUN apt-get install -y --no-install-recommends \
+    pkg-config:armhf \
+    qt6-base-dev:armhf \
+    libqt6svg6-dev:armhf \
+    qt6-tools-dev:armhf \
+    libavcodec-dev:armhf \
+    libavdevice-dev:armhf \
+    libavformat-dev:armhf \
+    libavutil-dev:armhf \
+    libswscale-dev:armhf \
+    libexif-dev:armhf \
+    libqrencode-dev:armhf \
+    libsqlcipher-dev:armhf \
+    libssl-dev:armhf \
+    libtoxcore-dev:armhf \
+    libsodium-dev:armhf \
+    libopus-dev:armhf \
+    libvpx-dev:armhf \
+    libopenal-dev:armhf \
+    libv4l-dev:armhf \
+    libx11-dev:armhf \
+    libxss-dev:armhf \
+    libunwind-dev:armhf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Uses the system (bookworm) toxcore, so an ancient one. We'll need to build some debs for toxcore as well soon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/274)
<!-- Reviewable:end -->
