### PR TITLE
Fix: 32-bit iOS builds failing due to targeting an iOS version that is too high

### DIFF
--- a/qtox/build_utils.sh
+++ b/qtox/build_utils.sh
@@ -128,6 +128,10 @@ parse_arch() {
     MAKE_JOBS="$(sysctl -n hw.ncpu)"
     CMAKE_TOOLCHAIN_FILE=("-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOS_MINIMUM_SUPPORTED_VERSION")
   elif [[ "$SCRIPT_ARCH" == "ios-"* ]]; then
+    if [ "$SCRIPT_ARCH" == "ios-armv7" ] || [ "$SCRIPT_ARCH" == "ios-armv7s" ]; then
+      # iOS 10 is the last deployment target supported for 32-bit builds, per a clang warning
+      IOS_MINIMUM_SUPPORTED_VERSION="10.0"
+    fi
     ARCH="${SCRIPT_ARCH#ios-}"
     DEP_PREFIX="${DEP_PREFIX:-/opt/buildhome}"
     mkdir -p "$DEP_PREFIX"


### PR DESCRIPTION
iOS 10 is the maximum deployment target for 32-bit builds, yet we are targeting iOS 15. It looks like clang was updated and added a warning for this at some point, so our builds now fail, since we `-Werror`.

Snippet of the CI failure from https://github.com/TokTok/c-toxcore/pull/3031:

```
2026-03-29T18:15:51.6473440Z configure:4287: checking whether the C compiler works
2026-03-29T18:15:51.6475210Z configure:4309: gcc -O3 -fPIC -miphoneos-version-min=15.0 -arch armv7 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk  -Dblake2b=sodium_blake2b -Dblake2b_final=sodium_blake2b_final -Dblake2b_init=sodium_blake2b_init -Dblake2b_init_key=sodium_blake2b_init_key -Dblake2b_init_param=sodium_blake2b_init_param -Dblake2b_update=sodium_blake2b_update  -miphoneos-version-min=15.0 -arch armv7 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -fstack-protector conftest.c  >&5
2026-03-29T18:15:51.6477350Z clang: error: invalid iOS deployment version '-miphoneos-version-min=15.0', iOS 10 is the maximum deployment target for 32-bit targets [-Winvalid-ios-deployment-target]
2026-03-29T18:15:51.6477870Z configure:4313: $? = 1
2026-03-29T18:15:51.6478020Z configure:4354: result: no
2026-03-29T18:15:51.6478170Z configure: failed program was:
2026-03-29T18:15:51.6478320Z | /* confdefs.h */
2026-03-29T18:15:51.6478460Z | #define PACKAGE_NAME "libsodium"
2026-03-29T18:15:51.6478640Z | #define PACKAGE_TARNAME "libsodium"
2026-03-29T18:15:51.6478820Z | #define PACKAGE_VERSION "1.0.20"
2026-03-29T18:15:51.6479370Z | #define PACKAGE_STRING "libsodium 1.0.20"
2026-03-29T18:15:51.6479710Z | #define PACKAGE_BUGREPORT "https://github.com/jedisct1/libsodium/issues"
2026-03-29T18:15:51.6480030Z | #define PACKAGE_URL "https://libsodium.org"
2026-03-29T18:15:51.6480230Z | #define PACKAGE "libsodium"
2026-03-29T18:15:51.6480390Z | #define VERSION "1.0.20"
2026-03-29T18:15:51.6480570Z | /* end confdefs.h.  */
2026-03-29T18:15:51.6480710Z | 
2026-03-29T18:15:51.6480800Z | int
2026-03-29T18:15:51.6480910Z | main (void)
2026-03-29T18:15:51.6481020Z | {
2026-03-29T18:15:51.6481110Z | 
2026-03-29T18:15:51.6481200Z |   ;
2026-03-29T18:15:51.6481300Z |   return 0;
2026-03-29T18:15:51.6481410Z | }
2026-03-29T18:15:51.6481620Z configure:4359: error: in '/Users/runner/work/c-toxcore/c-toxcore/external/sodium':
2026-03-29T18:15:51.6481970Z configure:4361: error: C compiler cannot create executables
2026-03-29T18:15:51.6482210Z See 'config.log' for more details
```

While c-toxcore's `other/deploy/ios.sh` script does attempt to set the version to iOS 10:

https://github.com/TokTok/c-toxcore/blob/8ffeabe452938609c3516665db2f14785f259d30/other/deploy/ios.sh#L23

it does so too late in the script, as it sets it only for building toxcore, not the deps. The failure happens during the dep building, in the `deps.sh` call, which calls `parse_arch` function from TokTok/Dockerfiles's `dockerfiles/qtox/build_utils.sh`, where it's hardcoded to 15.0 via `IOS_MINIMUM_SUPPORTED_VERSION=15.0`:

https://github.com/TokTok/dockerfiles/blob/0774716330d954cf1be991b515e2503078971dd5/qtox/build_utils.sh#L36

This PR fixes builds failing due to the clang warning being triggered by setting the `IOS_MINIMUM_SUPPORTED_VERSION` to 10.0 for 32-bit iOS builds.

I have tested this change in the mentioned PR https://github.com/TokTok/c-toxcore/pull/3031 with https://github.com/TokTok/c-toxcore/pull/3031/changes/d18ee91fe73b93c993842763d67886c57760a334 and it did indeed fix the failure.

---

When trying to figure out why the c-toxcore iOS CI is failing, seeing it call into qtox scripts raised some eyebrows here. I thought it might be mistakenly calling the wrong scripts, since c-toxcore shouldn't have anything to do with qtox. Surprised there is no common deps directory of sorts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/dockerfiles/275)
<!-- Reviewable:end -->
